### PR TITLE
fix(styled): always pass the entire expression from a styled function

### DIFF
--- a/packages/jest/src/index.tsx
+++ b/packages/jest/src/index.tsx
@@ -1,1 +1,10 @@
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toHaveCompiledCss(properties: { [key: string]: string }): R;
+      toHaveCompiledCss(property: string, value: string): R;
+    }
+  }
+}
+
 export { toHaveCompiledCss } from './matchers';

--- a/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
@@ -246,6 +246,19 @@ describe('styled component transformer', () => {
       expect(actual).toInclude('"--var-kmurgp": props.color }}');
     });
 
+    it('should transform a arrow function with a body into an IIFE', () => {
+      const actual = transformer.transform(`
+        import { styled } from '@compiled/css-in-js';
+
+        const ListItem = styled.div\`
+          color: \${props => { return props.color; }};
+        \`;
+      `);
+
+      expect(actual).toInclude('.test-class{color:var(--var-1bhsyr9);}');
+      expect(actual).toInclude('"--var-1bhsyr9": (() => { return props.color; })() }}');
+    });
+
     it('should transform template string literal with string import', () => {
       const actual = transformer.addSource({
         path: '/fonts.ts',

--- a/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
@@ -35,7 +35,7 @@ describe('styled component transformer', () => {
     `);
 
     expect(actual).toInclude('({ textSize, ...props }) =>');
-    expect(actual).toInclude('"--textSize-test-css-variable": textSize');
+    expect(actual).toInclude('"--var-1mnmsc": textSize');
   });
 
   xit('should compose using a previously created component', () => {
@@ -156,9 +156,9 @@ describe('styled component transformer', () => {
         \`;
       `);
 
-      expect(actual).toInclude('.test-class{font-size:var(--textSize-test-css-variable);}');
+      expect(actual).toInclude('.test-class{font-size:var(--var-1mnmsc);}');
       expect(actual).toInclude('({ textSize, ...props }) =>');
-      expect(actual).toInclude('"--textSize-test-css-variable": textSize + "px"');
+      expect(actual).toInclude('"--var-1mnmsc": textSize + "px"');
     });
 
     it('should persist suffix of dynamic property value into inline styles', () => {
@@ -242,8 +242,8 @@ describe('styled component transformer', () => {
         \`;
       `);
 
-      expect(actual).toInclude('.test-class{color:var(--color-test-css-variable);}');
-      expect(actual).toInclude('"--color-test-css-variable": props.color }}');
+      expect(actual).toInclude('.test-class{color:var(--var-kmurgp);}');
+      expect(actual).toInclude('"--var-kmurgp": props.color }}');
     });
 
     it('should transform template string literal with string import', () => {
@@ -474,9 +474,9 @@ describe('styled component transformer', () => {
         });
       `);
 
-      expect(actual).toInclude('.test-class{font-size:var(--textSize-test-css-variable);}');
+      expect(actual).toInclude('.test-class{font-size:var(--var-r807ho);}');
       expect(actual).toInclude('({ textSize, ...props }) =>');
-      expect(actual).toInclude('"--textSize-test-css-variable": `${textSize}px`');
+      expect(actual).toInclude('"--var-r807ho": `${textSize}px`');
     });
 
     it('should not pass down invalid html attributes to the node when property has a suffix when func in template literal', () => {
@@ -487,9 +487,9 @@ describe('styled component transformer', () => {
         });
       `);
 
-      expect(actual).toInclude('.test-class{font-size:var(--textSize-test-css-variable);}');
+      expect(actual).toInclude('.test-class{font-size:var(--var-1mnmsc);}');
       expect(actual).toInclude('({ textSize, ...props }) =>');
-      expect(actual).toInclude('"--textSize-test-css-variable": textSize + "px"');
+      expect(actual).toInclude('"--var-1mnmsc": textSize + "px"');
     });
 
     it('should persist suffix of dynamic property value into inline styles', () => {
@@ -503,8 +503,8 @@ describe('styled component transformer', () => {
         });
       `);
 
-      expect(actual).toInclude('"--fontSize-test-css-variable": props.fontSize + "px" }}');
-      expect(actual).toInclude('.test-class{font-size:var(--fontSize-test-css-variable);}');
+      expect(actual).toInclude('"--var-1dr62z0": props.fontSize + "px" }}');
+      expect(actual).toInclude('.test-class{font-size:var(--var-1dr62z0);}');
     });
 
     it('should transform object with simple values', () => {
@@ -590,8 +590,8 @@ describe('styled component transformer', () => {
         });
       `);
 
-      expect(actual).toInclude('.test-class{color:var(--color-test-css-variable);}');
-      expect(actual).toInclude('"--color-test-css-variable": props.color }}');
+      expect(actual).toInclude('.test-class{color:var(--var-kmurgp);}');
+      expect(actual).toInclude('"--var-kmurgp": props.color }}');
     });
 
     it('should transform object spread from variable', () => {

--- a/packages/ts-transform/src/utils/extract-css-var-from-arrow-function.tsx
+++ b/packages/ts-transform/src/utils/extract-css-var-from-arrow-function.tsx
@@ -2,14 +2,29 @@ import * as ts from 'typescript';
 import { CssVariableExpressions } from '../types';
 import { hash } from './sequential-chars';
 
+function wrapInIIFE(body: ts.Block): ts.CallExpression {
+  return ts.createCall(
+    ts.createParen(
+      ts.createArrowFunction(
+        undefined,
+        undefined,
+        [],
+        undefined,
+        ts.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+        body
+      )
+    ),
+    undefined,
+    []
+  );
+}
+
 export const extractCssVarFromArrowFunction = (
   node: ts.ArrowFunction,
   _: ts.TransformationContext
 ): CssVariableExpressions => {
-  const body: ts.Expression = (ts.isParenthesizedExpression(node.body)
-    ? node.body.expression
-    : node.body) as any;
-  const cssVariableName = hash(body.getText());
+  const bodyExpression: ts.Expression = ts.isBlock(node.body) ? wrapInIIFE(node.body) : node.body;
+  const cssVariableName = hash(node.body.getText());
 
-  return { expression: body, name: `--var-${cssVariableName}` };
+  return { expression: bodyExpression, name: `--var-${cssVariableName}` };
 };

--- a/packages/ts-transform/src/utils/extract-css-var-from-arrow-function.tsx
+++ b/packages/ts-transform/src/utils/extract-css-var-from-arrow-function.tsx
@@ -1,38 +1,15 @@
 import * as ts from 'typescript';
 import { CssVariableExpressions } from '../types';
-import { nextCssVariableName } from './identifiers';
-import { createNodeError } from './ast-node';
+import { hash } from './sequential-chars';
 
-/**
- * This expects a simple arrow function like the following:
- * `props => props.color`
- */
 export const extractCssVarFromArrowFunction = (
   node: ts.ArrowFunction,
   _: ts.TransformationContext
 ): CssVariableExpressions => {
-  let expression: ts.Expression = ts.createIdentifier('');
-  let name: string = '';
-  const body = ts.isParenthesizedExpression(node.body) ? node.body.expression : node.body;
+  const body: ts.Expression = (ts.isParenthesizedExpression(node.body)
+    ? node.body.expression
+    : node.body) as any;
+  const cssVariableName = hash(body.getText());
 
-  if (ts.isPropertyAccessExpression(body)) {
-    // We are returning a property immediately.
-    name = body.name.escapedText.toString();
-    // This changes props.color into an identifier instead.
-    // Technically this isn't right - we'll have to fix it sometime.
-    expression = ts.createIdentifier(body.getText());
-  } else if (ts.isTemplateExpression(body)) {
-    // TODO: Handle multiple expressions.
-    body.templateSpans.forEach(span => {
-      if (ts.isPropertyAccessExpression(span.expression)) {
-        name = span.expression.name.escapedText.toString();
-      }
-    });
-
-    expression = body;
-  } else {
-    throw createNodeError('unsupported arrow function body', node);
-  }
-
-  return { expression, name: `--${name}-${nextCssVariableName()}` };
+  return { expression: body, name: `--var-${cssVariableName}` };
 };


### PR DESCRIPTION
Closes #76 

TODO:
- [x] fix tests
- [x] add support for arrow functions with brackets