### PR TITLE
BREAKING: Removes need for jsx pragma

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,7 @@ npm i parcel-plugin-ttypescript --save-dev
 ### `css` prop
 
 ```jsx
-/** @jsx jsx */
-import { jsx } from '@compiled/css-in-js';
+import '@compiled/css-in-js/jsx';
 
 <div css={{ fontSize: 12 }} />;
 ```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ npm i parcel-plugin-ttypescript --save-dev
 ### `css` prop
 
 ```jsx
-import '@compiled/css-in-js/jsx';
+import '@compiled/css-in-js';
 
 <div css={{ fontSize: 12 }} />;
 ```

--- a/examples/css-prop-dynamic-object.tsx
+++ b/examples/css-prop-dynamic-object.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import '@compiled/css-in-js/jsx';
+import '@compiled/css-in-js';
 import { useState } from 'react';
 
 export default {

--- a/examples/css-prop-dynamic-object.tsx
+++ b/examples/css-prop-dynamic-object.tsx
@@ -1,5 +1,5 @@
-/** @jsx jsx */
-import { jsx } from '@compiled/css-in-js';
+import React from 'react';
+import '@compiled/css-in-js/jsx';
 import { useState } from 'react';
 
 export default {

--- a/examples/css-prop-static-object.tsx
+++ b/examples/css-prop-static-object.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import '@compiled/css-in-js/jsx';
+import '@compiled/css-in-js';
 import { hover } from './mixins/mixins';
 
 const inlineMixinFunc = () => ({

--- a/examples/css-prop-static-object.tsx
+++ b/examples/css-prop-static-object.tsx
@@ -1,5 +1,5 @@
-/** @jsx jsx */
-import { jsx } from '@compiled/css-in-js';
+import React from 'react';
+import '@compiled/css-in-js/jsx';
 import { hover } from './mixins/mixins';
 
 const inlineMixinFunc = () => ({

--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -42,8 +42,8 @@ describe('babel plugin', () => {
   it('should transform css prop', () => {
     const output = transformSync(
       `
-      /** @jsx jsx */
-      import { jsx } from '@compiled/css-in-js';
+      import '@compiled/css-in-js/jsx';
+      import React from 'react';
 
       <div css={{ fontSize: 12 }} />
     `,
@@ -52,9 +52,9 @@ describe('babel plugin', () => {
 
     expect(output?.code).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      /** @jsx jsx */
+      import '@compiled/css-in-js/jsx';
 
-      import { Style, jsx } from '@compiled/css-in-js';
+      import { Style } from '@compiled/css-in-js';
       <><Style hash=\\"css-1iqe21w\\">{[\\".css-1iqe21w{font-size:12px;}\\"]}</Style><div className=\\"css-1iqe21w\\" /></>;"
     `);
   });

--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -33,7 +33,7 @@ describe('babel plugin', () => {
 
     expect(output?.code).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { Style, styled } from '@compiled/css-in-js';
+      import { Style } from '@compiled/css-in-js';
 
       props => <><Style hash=\\"css-1x3e11p\\">{[\\".css-1x3e11p{font-size:12px;}\\"]}</Style><div {...props} className={\\"css-1x3e11p\\" + (props.className ? \\" \\" + props.className : \\"\\")}></div></>;"
     `);
@@ -42,8 +42,8 @@ describe('babel plugin', () => {
   it('should transform css prop', () => {
     const output = transformSync(
       `
-      import '@compiled/css-in-js/jsx';
       import React from 'react';
+      import '@compiled/css-in-js';
 
       <div css={{ fontSize: 12 }} />
     `,
@@ -51,9 +51,7 @@ describe('babel plugin', () => {
     );
 
     expect(output?.code).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
-      import '@compiled/css-in-js/jsx';
-
+      "import React from 'react';
       import { Style } from '@compiled/css-in-js';
       <><Style hash=\\"css-1iqe21w\\">{[\\".css-1iqe21w{font-size:12px;}\\"]}</Style><div className=\\"css-1iqe21w\\" /></>;"
     `);
@@ -72,7 +70,8 @@ describe('babel plugin', () => {
     );
 
     expect(output?.code).toMatchInlineSnapshot(`
-      "import { Style, ClassNames } from '@compiled/css-in-js';
+      "import React from \\"react\\";
+      import { Style } from '@compiled/css-in-js';
       <><Style hash=\\"css-2lhdif\\">{[\\".css-1iqe21w{font-size:12px;}\\"]}</Style><div className={\\"css-1iqe21w\\"} /></>;"
     `);
   });

--- a/packages/css-in-js/src/index.tsx
+++ b/packages/css-in-js/src/index.tsx
@@ -1,4 +1,3 @@
 export { default as Style } from '@compiled/style';
-export { jsx } from './jsx';
 export { styled } from './styled';
 export { ClassNames } from './class-names';

--- a/packages/css-in-js/src/jsx/__tests__/index.test.tsx
+++ b/packages/css-in-js/src/jsx/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import '@compiled/css-in-js/jsx';
+import '@compiled/css-in-js';
 import React from 'react';
 import { render } from '@testing-library/react';
 

--- a/packages/css-in-js/src/jsx/__tests__/index.test.tsx
+++ b/packages/css-in-js/src/jsx/__tests__/index.test.tsx
@@ -1,6 +1,4 @@
-/** @jsx jsx */
-import { jsx } from '@compiled/css-in-js';
-// @ts-ignore
+import '@compiled/css-in-js/jsx';
 import React from 'react';
 import { render } from '@testing-library/react';
 

--- a/packages/css-in-js/src/jsx/index.tsx
+++ b/packages/css-in-js/src/jsx/index.tsx
@@ -1,21 +1,20 @@
-import { ElementType, ReactNode } from 'react';
-import { CSSProp } from './types';
+import { CSSProperties } from 'react';
 import { createSetupError } from '../utils/error';
+
+export type CSS = CSSProperties;
 
 declare module 'react' {
   interface DOMAttributes<T> {
-    css?: CSSProp | { [key: string]: CSSProp } | string;
+    css?: CSS | { [key: string]: CSS } | string;
   }
 }
 
 declare global {
   namespace JSX {
     interface IntrinsicAttributes {
-      css?: CSSProp;
+      css?: CSSProperties;
     }
   }
 }
 
-export function jsx<P extends {}>(_: ElementType<P>, __: P, ...___: ReactNode[]) {
-  throw createSetupError();
-}
+throw createSetupError();

--- a/packages/css-in-js/src/jsx/types.tsx
+++ b/packages/css-in-js/src/jsx/types.tsx
@@ -1,3 +1,0 @@
-import { CSSProperties } from 'react';
-
-export type CSSProp = CSSProperties;

--- a/packages/css-in-js/src/utils/error.tsx
+++ b/packages/css-in-js/src/utils/error.tsx
@@ -1,36 +1,19 @@
 export const createSetupError = () => {
-  return `
-@compiled/css-in-js
+  return new Error(`
+ ██████╗ ██████╗ ███╗   ███╗██████╗ ██╗██╗     ███████╗██████╗
+██╔════╝██╔═══██╗████╗ ████║██╔══██╗██║██║     ██╔════╝██╔══██╗
+██║     ██║   ██║██╔████╔██║██████╔╝██║██║     █████╗  ██║  ██║
+██║     ██║   ██║██║╚██╔╝██║██╔═══╝ ██║██║     ██╔══╝  ██║  ██║
+╚██████╗╚██████╔╝██║ ╚═╝ ██║██║     ██║███████╗███████╗██████╔╝
+  ╚═════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝╚═════╝
 
-You need to apply the compiled css in js Typescript transformer to use this!
-Unsure what a Typescript transformer is? Read the handbook!
-https://github.com/madou/typescript-transformer-handbook
+  @compiled/css-in-js
 
-Quick setup:
+  Runtime code was executed when it shouldn't have. This could have happened because:
 
-1. Install ttypescript:
+  1. You haven't configured a transformer yet. Visit https://compiledcssinjs.com/docs and follow the instructions.
+  2. You have duplicate versions of React and hooks are blowing up. You need to de-duplicate your dependencies.
 
-  <code>npm i ttypescript</code>
-
-2. Add the transformer to your tsconfig.json:
-
-  <code>
-    {
-      "compilerOptions": {
-        "plugins": [{ "transform": "@compiled/css-in-js/dist/ts-transformer" }]
-      }
-    }
-  </code>
-
-3. Build your code with ttypescript:
-
-  - Using tsc CLI? Run ttsc instead of tsc
-  - Using Webpack? Update ts-loader options to point to ttypescript:
-    <code>
-      options: {
-        compiler: 'ttypescript',
-      }
-    </code>
-  - Using Parcel? Just install the plugin <code>npm i parcel-plugin-ttypescript</code>
-`;
+  Good luck!
+`);
 };

--- a/packages/css-in-js/tsconfig.json
+++ b/packages/css-in-js/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "dist",
     "baseUrl": "src",
     "paths": {
-      "@compiled/css-in-js": ["index.tsx"]
+      "@compiled/css-in-js": ["index.tsx"],
+      "@compiled/css-in-js/jsx": ["jsx.tsx"]
     }
   },
   "references": [{ "path": "../style" }]

--- a/packages/ts-transform/src/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/__tests__/index.test.tsx
@@ -15,8 +15,8 @@ describe('root transformer', () => {
     expect(() => {
       ts.transpileModule(
         `
-          /** @jsx jsx */
-          import { jsx } from '@compiled/css-in-js';
+          import '@compiled/css-in-js/jsx';
+          import React from 'react';
           const MyComponent = () => <div css={{ fontSize: '20px' }}>hello world</div>
         `,
         {
@@ -33,8 +33,8 @@ describe('root transformer', () => {
     expect(() => {
       ts.transpileModule(
         `
-          /** @jsx jsx */
-          import { jsx } from '@compiled/css-in-js';
+          import '@compiled/css-in-js/jsx';
+          import React from 'react';
           var MyComponent = () => <div css={{ fontSize: '20px' }}>hello world</div>
         `,
         {
@@ -57,8 +57,8 @@ describe('root transformer', () => {
 
     expect(() => {
       transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { mixin } from './mixins';
 
         <div css={{ ':hover': mixin }}>hello</div>
@@ -71,7 +71,7 @@ describe('root transformer', () => {
 
     const actual = ts.transpileModule(
       `
-        /** @jsx jsx */
+        import '@compiled/css-in-js/jsx';
         import { jsx, styled } from '@compiled/css-in-js';
 
         const StyledDiv = styled.div({});
@@ -95,8 +95,8 @@ describe('root transformer', () => {
 
     const actual = ts.transpileModule(
       `
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         <div css={{ fontSize: '20px' }}>hello world</div>
       `,
       {

--- a/packages/ts-transform/src/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/__tests__/index.test.tsx
@@ -8,6 +8,19 @@ const stubProgam: ts.Program = ({
   }),
 } as never) as ts.Program;
 
+const createTsConfig = (
+  transformer: ts.TransformerFactory<ts.SourceFile>,
+  overrides: ts.CompilerOptions = {}
+): ts.TranspileOptions => ({
+  transformers: { before: [transformer] },
+  compilerOptions: {
+    module: ts.ModuleKind.ES2015,
+    jsx: ts.JsxEmit.Preserve,
+    target: ts.ScriptTarget.ESNext,
+    ...overrides,
+  },
+});
+
 describe('root transformer', () => {
   it('should not blow up when transforming with const', () => {
     const transformer = rootTransformer(stubProgam, {});
@@ -15,14 +28,11 @@ describe('root transformer', () => {
     expect(() => {
       ts.transpileModule(
         `
-          import '@compiled/css-in-js/jsx';
+          import '@compiled/css-in-js';
           import React from 'react';
           const MyComponent = () => <div css={{ fontSize: '20px' }}>hello world</div>
         `,
-        {
-          transformers: { before: [transformer] },
-          compilerOptions: { module: ts.ModuleKind.ESNext, jsx: ts.JsxEmit.React },
-        }
+        createTsConfig(transformer)
       );
     }).not.toThrow();
   });
@@ -33,14 +43,11 @@ describe('root transformer', () => {
     expect(() => {
       ts.transpileModule(
         `
-          import '@compiled/css-in-js/jsx';
+          import '@compiled/css-in-js';
           import React from 'react';
           var MyComponent = () => <div css={{ fontSize: '20px' }}>hello world</div>
         `,
-        {
-          transformers: { before: [transformer] },
-          compilerOptions: { module: ts.ModuleKind.ESNext, jsx: ts.JsxEmit.React },
-        }
+        createTsConfig(transformer)
       );
     }).not.toThrow();
   });
@@ -49,7 +56,7 @@ describe('root transformer', () => {
     const transformer = new Transformer()
       .addTransformer(rootTransformer)
       .setFilePath('/index.tsx')
-      .addMock({ name: '@compiled/css-in-js', content: `export const jsx: any = () => null` })
+      .addMock({ name: 'react', content: `export default null;` })
       .addSource({
         path: '/mixins.ts',
         contents: "export const mixin = { color: 'blue' };",
@@ -57,7 +64,7 @@ describe('root transformer', () => {
 
     expect(() => {
       transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { mixin } from './mixins';
 
@@ -71,23 +78,15 @@ describe('root transformer', () => {
 
     const actual = ts.transpileModule(
       `
-        import '@compiled/css-in-js/jsx';
-        import { jsx, styled } from '@compiled/css-in-js';
+        import { styled } from '@compiled/css-in-js';
 
         const StyledDiv = styled.div({});
         <div css={{ fontSize: '20px' }}>hello world</div>
       `,
-      {
-        transformers: { before: [transformer] },
-        compilerOptions: {
-          module: ts.ModuleKind.ES2015,
-          esModuleInterop: true,
-          jsx: ts.JsxEmit.React,
-        },
-      }
+      createTsConfig(transformer)
     );
 
-    expect(actual.outputText).toInclude("import { Style, jsx, styled } from '@compiled/css-in-js'");
+    expect(actual.outputText).toInclude("import { Style } from '@compiled/css-in-js'");
   });
 
   xit('should match react import when transforming to common js', () => {
@@ -95,22 +94,95 @@ describe('root transformer', () => {
 
     const actual = ts.transpileModule(
       `
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         <div css={{ fontSize: '20px' }}>hello world</div>
       `,
-      {
-        transformers: { before: [transformer] },
-        compilerOptions: {
-          module: ts.ModuleKind.CommonJS,
-          esModuleInterop: true,
-          jsx: ts.JsxEmit.React,
-        },
-      }
+      createTsConfig(transformer, { module: ts.ModuleKind.CommonJS })
     );
 
     expect(actual.outputText).toInclude('var react_1 = __importDefault(require("react"));');
     expect(actual.outputText).toInclude('react_1.createElement');
     expect(actual.outputText).not.toInclude('React.createElement');
+  });
+
+  it('should not change code where there is no compiled components', () => {
+    const transformer = rootTransformer(stubProgam, {});
+
+    const actual = ts.transpileModule(
+      `
+      const one = 1;
+    `,
+      createTsConfig(transformer)
+    );
+
+    expect(actual.outputText).toMatchInlineSnapshot(`
+      "const one = 1;
+      "
+    `);
+  });
+
+  it('should transform a styled component', () => {
+    const transformer = rootTransformer(stubProgam, {});
+
+    const actual = ts.transpileModule(
+      `
+      import { styled } from '@compiled/css-in-js';
+
+      styled.div\`
+        font-size: 12px;
+      \`;
+    `,
+      createTsConfig(transformer)
+    );
+
+    expect(actual.outputText).toMatchInlineSnapshot(`
+      "import React from \\"react\\";
+      import { Style } from '@compiled/css-in-js';
+      props => <><Style hash=\\"css-1x3e11p\\">{[\\".css-1x3e11p{font-size:12px;}\\"]}</Style><div {...props} className={\\"css-1x3e11p\\" + (props.className ? \\" \\" + props.className : \\"\\")}></div></>;
+      "
+    `);
+  });
+
+  it('should transform css prop', () => {
+    const transformer = rootTransformer(stubProgam, {});
+
+    const actual = ts.transpileModule(
+      `
+      import '@compiled/css-in-js';
+
+      <div css={{ fontSize: 12 }} />
+    `,
+      createTsConfig(transformer)
+    );
+
+    expect(actual.outputText).toMatchInlineSnapshot(`
+      "import React from \\"react\\";
+      import { Style } from '@compiled/css-in-js';
+      <><Style hash=\\"css-1iqe21w\\">{[\\".css-1iqe21w{font-size:12px;}\\"]}</Style><div className=\\"css-1iqe21w\\"/></>;
+      "
+    `);
+  });
+
+  it('should transform classnames component', () => {
+    const transformer = rootTransformer(stubProgam, {});
+
+    const actual = ts.transpileModule(
+      `
+      import { ClassNames } from '@compiled/css-in-js';
+
+      <ClassNames>
+        {({ css }) => <div className={css({ fontSize: 12 })} />}
+      </ClassNames>
+    `,
+      createTsConfig(transformer)
+    );
+
+    expect(actual.outputText).toMatchInlineSnapshot(`
+      "import React from \\"react\\";
+      import { Style } from '@compiled/css-in-js';
+      <><Style hash=\\"css-2lhdif\\">{[\\".css-1iqe21w{font-size:12px;}\\"]}</Style><div className={\\"css-1iqe21w\\"}/></>;
+      "
+    `);
   });
 });

--- a/packages/ts-transform/src/class-names/index.tsx
+++ b/packages/ts-transform/src/class-names/index.tsx
@@ -28,16 +28,13 @@ export default function classNamesTransformer(
         return sourceFile;
       }
 
-      const transformedSourceFile = visitSourceFileEnsureStyleImport(sourceFile, context);
+      const transformedSourceFile = visitSourceFileEnsureStyleImport(sourceFile, context, {
+        removeNamedImport: CLASS_NAMES_NAME,
+      });
       const collectedDeclarations: Declarations = {};
 
       const visitor = (node: ts.Node): ts.Node => {
         collectDeclarationsFromNode(node, program, collectedDeclarations);
-
-        // TODO: Remove CLASS_NAMES_NAME import instead of entire statement.
-        // if (isPackageModuleImport(node, CLASS_NAMES_NAME)) {
-        //   return ts.createEmptyStatement();
-        // }
 
         if (isClassNameComponent(node)) {
           return visitClassNamesJsxElement(node, context, collectedDeclarations);

--- a/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
@@ -16,8 +16,8 @@ const transformer = new Transformer()
 describe('css prop transformer', () => {
   it('should transform a self closing element', () => {
     const actual = transformer.transform(`
-      /** @jsx jsx */
-      import { jsx } from '@compiled/css-in-js';
+      import '@compiled/css-in-js/jsx';
+      import React from 'react';
 
       <div css={{}} />
     `);
@@ -27,8 +27,8 @@ describe('css prop transformer', () => {
 
   it('should replace css prop with class name', () => {
     const actual = transformer.transform(`
-      /** @jsx jsx */
-      import { jsx } from '@compiled/css-in-js';
+      import '@compiled/css-in-js/jsx';
+      import React from 'react';
 
       <div css={{}}>hello world</div>
     `);
@@ -38,8 +38,8 @@ describe('css prop transformer', () => {
 
   it('should add react default import if missing', () => {
     const actual = transformer.transform(`
-      /** @jsx jsx */
-      import { jsx } from '@compiled/css-in-js';
+      import '@compiled/css-in-js/jsx';
+      import React from 'react';
 
       <div css={{}}>hello world</div>
     `);
@@ -49,21 +49,19 @@ describe('css prop transformer', () => {
 
   it('should ensure Style has been imported', () => {
     const actual = transformer.transform(`
-      /** @jsx jsx */
+      import '@compiled/css-in-js/jsx';
       import React from 'react';
-      import { jsx } from '@compiled/css-in-js';
 
       <div css={{}}>hello world</div>
     `);
 
-    expect(actual).toIncludeRepeated(`import { Style, jsx } from '@compiled/css-in-js';`, 1);
+    expect(actual).toIncludeRepeated(`import { Style } from '@compiled/css-in-js';`, 1);
   });
 
   it('should do nothing if react default import is already defined', () => {
     const actual = transformer.transform(`
-      /** @jsx jsx */
+      import '@compiled/css-in-js/jsx';
       import React from 'react';
-      import { jsx } from '@compiled/css-in-js';
 
       <div css={{}}>hello world</div>
     `);
@@ -73,9 +71,9 @@ describe('css prop transformer', () => {
 
   it('should add react default import if it only has named imports', () => {
     const actual = transformer.transform(`
-      /** @jsx jsx */
+      import '@compiled/css-in-js/jsx';
       import { useState } from 'react';
-      import { jsx } from '@compiled/css-in-js';
+      import React from 'react';
 
       <div css={{}}>hello world</div>
     `);
@@ -85,8 +83,8 @@ describe('css prop transformer', () => {
 
   it('should concat explicit use of class name prop on an element', () => {
     const actual = transformer.transform(`
-      /** @jsx jsx */
-      import { jsx } from '@compiled/css-in-js';
+      import '@compiled/css-in-js/jsx';
+      import React from 'react';
 
       <div className="foobar" css={{}}>hello world</div>
     `);
@@ -98,8 +96,8 @@ describe('css prop transformer', () => {
 
   it('should concat implicit use of class name prop where class name is a jsx expression', () => {
     const actual = transformer.transform(`
-      /** @jsx jsx */
-      import { jsx } from '@compiled/css-in-js';
+      import '@compiled/css-in-js/jsx';
+      import React from 'react';
 
       const getFoo = () => 'foobar';
 
@@ -111,8 +109,8 @@ describe('css prop transformer', () => {
 
   it('should concat use of inline styles when there is use of dynamic css', () => {
     const actual = transformer.transform(`
-      /** @jsx jsx */
-      import { jsx } from '@compiled/css-in-js';
+      import '@compiled/css-in-js/jsx';
+      import React from 'react';
 
       const color = 'blue';
 
@@ -127,8 +125,8 @@ describe('css prop transformer', () => {
   describe('using strings', () => {
     it('should persist suffix of dynamic property value into inline styles', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const fontSize = 20;
 
@@ -141,8 +139,8 @@ describe('css prop transformer', () => {
 
     it('should transform string literal', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         <div css="font-size: 20px;">hello world</div>
     `);
@@ -152,8 +150,8 @@ describe('css prop transformer', () => {
 
     it('should transform no template string literal', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         <div css={\`font-size: 20px;\`}>hello world</div>
     `);
@@ -163,8 +161,8 @@ describe('css prop transformer', () => {
 
     it('should transform template string literal with string variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const color = 'blue';
         <div css={\`color: \${color};\`}>hello world</div>
@@ -178,8 +176,8 @@ describe('css prop transformer', () => {
 
     it('should transform template string literal with obj variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const style = { color: 'blue', fontSize: '30px' };
         <div css={\`\${style}\`}>hello world</div>
@@ -193,8 +191,8 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: `export const style = { color: 'blue', fontSize: '30px' };`,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { style } from './mixins';
 
         <div
@@ -216,8 +214,8 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: `export const style = { ':hover': { color: 'blue', fontSize: '30px' } };`,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { style } from './mixins';
 
         <div css={\`\${style}\`}>hello world</div>
@@ -232,8 +230,8 @@ describe('css prop transformer', () => {
 
     it('should transform template string with no argument arrow function variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const style = () => ({ color: 'blue', fontSize: '30px' });
         <div css={\`\${style}\`}>hello world</div>
@@ -244,8 +242,8 @@ describe('css prop transformer', () => {
 
     it('should transform template string with no argument arrow function call variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const style = () => ({ color: 'blue', fontSize: '30px' });
         <div css={\`\${style()}\`}>hello world</div>
@@ -259,8 +257,8 @@ describe('css prop transformer', () => {
         path: '/stylez.ts',
         contents: `export const style = () => ({ color: 'blue', fontSize: '30px' });`,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { style } from './stylez';
 
         <div css={\`\${style()}\`}>hello world</div>
@@ -271,8 +269,8 @@ describe('css prop transformer', () => {
 
     it('should transform template string with no argument function variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         function mixin() {
           return { color: 'red' };
@@ -293,8 +291,8 @@ describe('css prop transformer', () => {
           }
         `,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { mixin } from './func-mixin';
 
         <div css={\`\${mixin()}\`}>hello world</div>
@@ -309,8 +307,8 @@ describe('css prop transformer', () => {
 
     xit('should transform template string with argument arrow function variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const style = (color: string) => ({ color, fontSize: '30px' });
         const primary = 'red';
@@ -326,8 +324,8 @@ describe('css prop transformer', () => {
         path: '/mixy-in.ts',
         contents: `export const style = (color: string) => ({ color, fontSize: '30px' });`,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { style } from './mixy-in';
 
         const primary = 'red';
@@ -342,8 +340,8 @@ describe('css prop transformer', () => {
   describe('using an object literal', () => {
     it('should persist suffix of dynamic property value into inline styles', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const fontSize = 20;
 
@@ -356,8 +354,8 @@ describe('css prop transformer', () => {
 
     it('should transform object with simple values', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         <div css={{ lineHeight: 20, color: 'blue' }}>hello world</div>
       `);
@@ -367,8 +365,8 @@ describe('css prop transformer', () => {
 
     it('should move right hand value (px, em, etc) after variable into style attribute', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const fontSize = 12;
 
@@ -381,8 +379,8 @@ describe('css prop transformer', () => {
 
     it('should transform object with nested object into a selector', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         <div css={{ ':hover': { color: 'blue' } }}>hello world</div>
       `);
@@ -392,8 +390,8 @@ describe('css prop transformer', () => {
 
     it('should transform object that has a variable reference', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const blue: string = 'blue';
         <div css={{ color: blue }}>hello world</div>
@@ -405,9 +403,9 @@ describe('css prop transformer', () => {
 
     it('should transform object that has a destructured variable reference', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
+        import '@compiled/css-in-js/jsx';
         import { useState } from 'react';
-        import { jsx } from '@compiled/css-in-js';
+        import React from 'react';
 
         const [color, setColor] = useState('blue');
         <div css={{ color }}>hello world</div>
@@ -421,8 +419,8 @@ describe('css prop transformer', () => {
 
     it('should transform object spread from variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const mixin = { color: 'red' };
         <div css={{ color: 'blue', ...mixin }}>hello world</div>
@@ -436,8 +434,8 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: `export const mixin = { color: 'red' };`,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { mixin } from './mixins';
 
         <div css={{ color: 'blue', ...mixin }}>hello world</div>
@@ -448,8 +446,8 @@ describe('css prop transformer', () => {
 
     it('should transform object with string variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const text = 'red';
 
@@ -462,8 +460,8 @@ describe('css prop transformer', () => {
 
     it('should transform object with string variable using shorthand notation', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const color = 'red';
 
@@ -479,8 +477,8 @@ describe('css prop transformer', () => {
         path: '/colors.tsx',
         contents: `export const color = 'red';`,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { color } from './colors';
 
         <div css={{ color }}>hello world</div>
@@ -492,8 +490,8 @@ describe('css prop transformer', () => {
 
     it('should transform object with obj variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const mixin = { color: 'blue' };
 
@@ -519,8 +517,8 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: "export const mixin = { color: 'blue' };",
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { mixin } from './mixins';
 
         <div
@@ -546,8 +544,8 @@ describe('css prop transformer', () => {
 
     it('should transform object with no argument arrow function variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const mixin = () => ({ color: 'red' });
 
@@ -562,8 +560,8 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: `export const mixin = () => ({ color: 'red' });`,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { mixin } from './mixins';
 
         <div css={{ color: 'blue', ...mixin() }}>hello world</div>
@@ -574,8 +572,8 @@ describe('css prop transformer', () => {
 
     it('should transform object spread with no argument arrow function variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const mixin = () => ({ color: 'red' });
 
@@ -590,8 +588,8 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: `export const mixin = () => ({ color: 'red' });`,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { mixin } from './mixins';
 
         <div css={{ color: 'blue', ...mixin() }}>hello world</div>
@@ -602,8 +600,8 @@ describe('css prop transformer', () => {
 
     it('should transform object spread with no argument function variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         function mixin() {
           return { color: 'red' };
@@ -617,8 +615,8 @@ describe('css prop transformer', () => {
 
     it('should transform object with no argument arrow function', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const mixin = () => ({ color: 'red' });
 
@@ -631,8 +629,8 @@ describe('css prop transformer', () => {
 
     it('should transform object with no argument function variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         function mixin() {
           return { color: 'red' };
@@ -654,8 +652,8 @@ describe('css prop transformer', () => {
           }
         `,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { mixin } from './mixins';
 
         <div css={{ color: 'blue', ':hover': mixin() }}>hello world</div>
@@ -667,8 +665,8 @@ describe('css prop transformer', () => {
 
     it('should transform object spread with no argument function variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         function mixin() {
           return { color: 'red' };
@@ -689,8 +687,8 @@ describe('css prop transformer', () => {
           }
         `,
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { mixin } from './mixins';
 
         <div css={{ color: 'blue', ...mixin() }}>hello world</div>
@@ -705,8 +703,8 @@ describe('css prop transformer', () => {
 
     it('should transform object with argument arrow function variable', () => {
       const actual = transformer.transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
 
         const mixin = (color: string) => ({ color });
         const color = 'red';
@@ -723,8 +721,8 @@ describe('css prop transformer', () => {
         path: '/styles.ts',
         contents: 'export const mixin = (color: string) => ({ color });',
       }).transform(`
-        /** @jsx jsx */
-        import { jsx } from '@compiled/css-in-js';
+        import '@compiled/css-in-js/jsx';
+        import React from 'react';
         import { mixin } from './styles';
 
         const color = 'red';

--- a/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
@@ -16,7 +16,7 @@ const transformer = new Transformer()
 describe('css prop transformer', () => {
   it('should transform a self closing element', () => {
     const actual = transformer.transform(`
-      import '@compiled/css-in-js/jsx';
+      import '@compiled/css-in-js';
       import React from 'react';
 
       <div css={{}} />
@@ -27,7 +27,7 @@ describe('css prop transformer', () => {
 
   it('should replace css prop with class name', () => {
     const actual = transformer.transform(`
-      import '@compiled/css-in-js/jsx';
+      import '@compiled/css-in-js';
       import React from 'react';
 
       <div css={{}}>hello world</div>
@@ -38,18 +38,18 @@ describe('css prop transformer', () => {
 
   it('should add react default import if missing', () => {
     const actual = transformer.transform(`
-      import '@compiled/css-in-js/jsx';
+      import '@compiled/css-in-js';
       import React from 'react';
 
       <div css={{}}>hello world</div>
     `);
 
-    expect(actual).toInclude(`import React from \"react\";`);
+    expect(actual).toInclude(`import React from \'react\';`);
   });
 
   it('should ensure Style has been imported', () => {
     const actual = transformer.transform(`
-      import '@compiled/css-in-js/jsx';
+      import '@compiled/css-in-js';
       import React from 'react';
 
       <div css={{}}>hello world</div>
@@ -60,7 +60,7 @@ describe('css prop transformer', () => {
 
   it('should do nothing if react default import is already defined', () => {
     const actual = transformer.transform(`
-      import '@compiled/css-in-js/jsx';
+      import '@compiled/css-in-js';
       import React from 'react';
 
       <div css={{}}>hello world</div>
@@ -71,7 +71,7 @@ describe('css prop transformer', () => {
 
   it('should add react default import if it only has named imports', () => {
     const actual = transformer.transform(`
-      import '@compiled/css-in-js/jsx';
+      import '@compiled/css-in-js';
       import { useState } from 'react';
       import React from 'react';
 
@@ -83,7 +83,7 @@ describe('css prop transformer', () => {
 
   it('should concat explicit use of class name prop on an element', () => {
     const actual = transformer.transform(`
-      import '@compiled/css-in-js/jsx';
+      import '@compiled/css-in-js';
       import React from 'react';
 
       <div className="foobar" css={{}}>hello world</div>
@@ -96,7 +96,7 @@ describe('css prop transformer', () => {
 
   it('should concat implicit use of class name prop where class name is a jsx expression', () => {
     const actual = transformer.transform(`
-      import '@compiled/css-in-js/jsx';
+      import '@compiled/css-in-js';
       import React from 'react';
 
       const getFoo = () => 'foobar';
@@ -109,7 +109,7 @@ describe('css prop transformer', () => {
 
   it('should concat use of inline styles when there is use of dynamic css', () => {
     const actual = transformer.transform(`
-      import '@compiled/css-in-js/jsx';
+      import '@compiled/css-in-js';
       import React from 'react';
 
       const color = 'blue';
@@ -125,7 +125,7 @@ describe('css prop transformer', () => {
   describe('using strings', () => {
     it('should persist suffix of dynamic property value into inline styles', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const fontSize = 20;
@@ -139,7 +139,7 @@ describe('css prop transformer', () => {
 
     it('should transform string literal', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         <div css="font-size: 20px;">hello world</div>
@@ -150,7 +150,7 @@ describe('css prop transformer', () => {
 
     it('should transform no template string literal', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         <div css={\`font-size: 20px;\`}>hello world</div>
@@ -161,7 +161,7 @@ describe('css prop transformer', () => {
 
     it('should transform template string literal with string variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const color = 'blue';
@@ -176,7 +176,7 @@ describe('css prop transformer', () => {
 
     it('should transform template string literal with obj variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const style = { color: 'blue', fontSize: '30px' };
@@ -191,7 +191,7 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: `export const style = { color: 'blue', fontSize: '30px' };`,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { style } from './mixins';
 
@@ -214,7 +214,7 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: `export const style = { ':hover': { color: 'blue', fontSize: '30px' } };`,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { style } from './mixins';
 
@@ -230,7 +230,7 @@ describe('css prop transformer', () => {
 
     it('should transform template string with no argument arrow function variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const style = () => ({ color: 'blue', fontSize: '30px' });
@@ -242,7 +242,7 @@ describe('css prop transformer', () => {
 
     it('should transform template string with no argument arrow function call variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const style = () => ({ color: 'blue', fontSize: '30px' });
@@ -257,7 +257,7 @@ describe('css prop transformer', () => {
         path: '/stylez.ts',
         contents: `export const style = () => ({ color: 'blue', fontSize: '30px' });`,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { style } from './stylez';
 
@@ -269,7 +269,7 @@ describe('css prop transformer', () => {
 
     it('should transform template string with no argument function variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         function mixin() {
@@ -291,7 +291,7 @@ describe('css prop transformer', () => {
           }
         `,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { mixin } from './func-mixin';
 
@@ -307,7 +307,7 @@ describe('css prop transformer', () => {
 
     xit('should transform template string with argument arrow function variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const style = (color: string) => ({ color, fontSize: '30px' });
@@ -324,7 +324,7 @@ describe('css prop transformer', () => {
         path: '/mixy-in.ts',
         contents: `export const style = (color: string) => ({ color, fontSize: '30px' });`,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { style } from './mixy-in';
 
@@ -340,7 +340,7 @@ describe('css prop transformer', () => {
   describe('using an object literal', () => {
     it('should persist suffix of dynamic property value into inline styles', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const fontSize = 20;
@@ -354,7 +354,7 @@ describe('css prop transformer', () => {
 
     it('should transform object with simple values', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         <div css={{ lineHeight: 20, color: 'blue' }}>hello world</div>
@@ -365,7 +365,7 @@ describe('css prop transformer', () => {
 
     it('should move right hand value (px, em, etc) after variable into style attribute', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const fontSize = 12;
@@ -379,7 +379,7 @@ describe('css prop transformer', () => {
 
     it('should transform object with nested object into a selector', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         <div css={{ ':hover': { color: 'blue' } }}>hello world</div>
@@ -390,7 +390,7 @@ describe('css prop transformer', () => {
 
     it('should transform object that has a variable reference', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const blue: string = 'blue';
@@ -403,7 +403,7 @@ describe('css prop transformer', () => {
 
     it('should transform object that has a destructured variable reference', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import { useState } from 'react';
         import React from 'react';
 
@@ -419,7 +419,7 @@ describe('css prop transformer', () => {
 
     it('should transform object spread from variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const mixin = { color: 'red' };
@@ -434,7 +434,7 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: `export const mixin = { color: 'red' };`,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { mixin } from './mixins';
 
@@ -446,7 +446,7 @@ describe('css prop transformer', () => {
 
     it('should transform object with string variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const text = 'red';
@@ -460,7 +460,7 @@ describe('css prop transformer', () => {
 
     it('should transform object with string variable using shorthand notation', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const color = 'red';
@@ -477,7 +477,7 @@ describe('css prop transformer', () => {
         path: '/colors.tsx',
         contents: `export const color = 'red';`,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { color } from './colors';
 
@@ -490,7 +490,7 @@ describe('css prop transformer', () => {
 
     it('should transform object with obj variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const mixin = { color: 'blue' };
@@ -517,7 +517,7 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: "export const mixin = { color: 'blue' };",
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { mixin } from './mixins';
 
@@ -544,7 +544,7 @@ describe('css prop transformer', () => {
 
     it('should transform object with no argument arrow function variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const mixin = () => ({ color: 'red' });
@@ -560,7 +560,7 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: `export const mixin = () => ({ color: 'red' });`,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { mixin } from './mixins';
 
@@ -572,7 +572,7 @@ describe('css prop transformer', () => {
 
     it('should transform object spread with no argument arrow function variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const mixin = () => ({ color: 'red' });
@@ -588,7 +588,7 @@ describe('css prop transformer', () => {
         path: '/mixins.ts',
         contents: `export const mixin = () => ({ color: 'red' });`,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { mixin } from './mixins';
 
@@ -600,7 +600,7 @@ describe('css prop transformer', () => {
 
     it('should transform object spread with no argument function variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         function mixin() {
@@ -615,7 +615,7 @@ describe('css prop transformer', () => {
 
     it('should transform object with no argument arrow function', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const mixin = () => ({ color: 'red' });
@@ -629,7 +629,7 @@ describe('css prop transformer', () => {
 
     it('should transform object with no argument function variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         function mixin() {
@@ -652,7 +652,7 @@ describe('css prop transformer', () => {
           }
         `,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { mixin } from './mixins';
 
@@ -665,7 +665,7 @@ describe('css prop transformer', () => {
 
     it('should transform object spread with no argument function variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         function mixin() {
@@ -687,7 +687,7 @@ describe('css prop transformer', () => {
           }
         `,
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { mixin } from './mixins';
 
@@ -703,7 +703,7 @@ describe('css prop transformer', () => {
 
     it('should transform object with argument arrow function variable', () => {
       const actual = transformer.transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
 
         const mixin = (color: string) => ({ color });
@@ -721,7 +721,7 @@ describe('css prop transformer', () => {
         path: '/styles.ts',
         contents: 'export const mixin = (color: string) => ({ color });',
       }).transform(`
-        import '@compiled/css-in-js/jsx';
+        import '@compiled/css-in-js';
         import React from 'react';
         import { mixin } from './styles';
 

--- a/packages/ts-transform/src/css-prop/index.tsx
+++ b/packages/ts-transform/src/css-prop/index.tsx
@@ -10,22 +10,13 @@ import { visitSourceFileEnsureStyleImport } from '../utils/visit-source-file-ens
 import { isPackageModuleImport } from '../utils/ast-node';
 import { collectDeclarationsFromNode } from '../utils/collect-declarations';
 
-const JSX_PRAGMA = 'jsx';
-
 const isJsxPragmaFoundWithOurJsxFunction = (sourceFile: ts.SourceFile) => {
   return (
-    // __HACK_ALERT__!! This isn't in the TS types. Is this bad?
-    (sourceFile as any).pragmas.get(JSX_PRAGMA) &&
     // Only continue if we've found an import for this pkg.
     sourceFile.statements.find(statement => {
-      return isPackageModuleImport(statement, JSX_PRAGMA);
+      return isPackageModuleImport(statement);
     })
   );
-};
-
-const resetJsxPragma = (sourceFile: ts.SourceFile) => {
-  ((sourceFile as any).pragmas as Map<any, any>).clear();
-  delete (sourceFile as any).localJsxFactory;
 };
 
 export default function cssPropTransformer(
@@ -37,8 +28,6 @@ export default function cssPropTransformer(
         // nothing to do - return source file and nothing will be transformed.
         return sourceFile;
       }
-
-      resetJsxPragma(sourceFile);
 
       const collectedDeclarations: Declarations = {};
       logger.log('found file with jsx pragma');

--- a/packages/ts-transform/src/styled-component/index.tsx
+++ b/packages/ts-transform/src/styled-component/index.tsx
@@ -44,18 +44,13 @@ export default function styledComponentTransformer(
       }
 
       const transformedSourceFile = visitSourceFileEnsureDefaultReactImport(
-        visitSourceFileEnsureStyleImport(sourceFile, context),
+        visitSourceFileEnsureStyleImport(sourceFile, context, { removeNamedImport: STYLED_NAME }),
         context
       );
       const collectedDeclarations: Declarations = {};
 
       const visitor = (node: ts.Node): ts.Node => {
         collectDeclarationsFromNode(node, program, collectedDeclarations);
-
-        // TODO: Remove STYLED_NAME import instead of removing entire thing.
-        // if (isPackageModuleImport(node, STYLED_NAME)) {
-        //   return ts.createEmptyStatement();
-        // }
 
         if (isStyledComponent(node)) {
           return visitStyledComponent(node, context, collectedDeclarations);

--- a/packages/ts-transform/src/utils/ast-node.tsx
+++ b/packages/ts-transform/src/utils/ast-node.tsx
@@ -47,18 +47,24 @@ export const getJsxNodeAttributesValue = (
   return attribute?.initializer ? attribute.initializer : undefined;
 };
 
-export const isPackageModuleImport = (statement: ts.Node, namedImport: string): boolean => {
-  if (
-    !ts.isImportDeclaration(statement) ||
-    !ts.isStringLiteral(statement.moduleSpecifier) ||
-    !statement.importClause?.namedBindings ||
-    !ts.isNamedImports(statement.importClause?.namedBindings)
-  ) {
+export const isPackageModuleImport = (statement: ts.Node, namedImport?: string): boolean => {
+  if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) {
     return false;
   }
 
-  const isLibraryImport = statement.moduleSpecifier.text === '@compiled/css-in-js';
+  const isLibraryImport = statement.moduleSpecifier.text.startsWith('@compiled/css-in-js');
   if (!isLibraryImport) {
+    return false;
+  }
+
+  if (namedImport === undefined) {
+    return true;
+  }
+
+  if (
+    !statement.importClause?.namedBindings ||
+    !ts.isNamedImports(statement.importClause?.namedBindings)
+  ) {
     return false;
   }
 


### PR DESCRIPTION
Removes need for jsx pragma.

Instead of using jsx import with jsx pragma `/** @jsx jsx */` - import compiled `import '@compiled/css-in-js'` and `css` prop will be enabled.

A new feature will be added later to remove the need for importing compiled at all - probably under a `useCssProp` config option.

Closes #87 #88.
