### PR TITLE
Generated css name should not collide with emotion - fixes #131

### DIFF
--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -37,7 +37,7 @@ describe('babel plugin', () => {
       React.forwardRef(({
         as: C = \\"div\\",
         ...props
-      }, ref) => <><Style hash=\\"css-1x3e11p\\">{[\\".css-1x3e11p{font-size:12px;}\\"]}</Style><C {...props} ref={ref} className={\\"css-1x3e11p\\" + (props.className ? \\" \\" + props.className : \\"\\")} /></>);"
+      }, ref) => <><Style hash=\\"cc-1x3e11p\\">{[\\".cc-1x3e11p{font-size:12px;}\\"]}</Style><C {...props} ref={ref} className={\\"cc-1x3e11p\\" + (props.className ? \\" \\" + props.className : \\"\\")} /></>);"
     `);
   });
 
@@ -55,7 +55,7 @@ describe('babel plugin', () => {
     expect(output?.code).toMatchInlineSnapshot(`
       "import React from 'react';
       import { Style } from '@compiled/css-in-js';
-      <><Style hash=\\"css-1iqe21w\\">{[\\".css-1iqe21w{font-size:12px;}\\"]}</Style><div className=\\"css-1iqe21w\\" /></>;"
+      <><Style hash=\\"cc-1iqe21w\\">{[\\".cc-1iqe21w{font-size:12px;}\\"]}</Style><div className=\\"cc-1iqe21w\\" /></>;"
     `);
   });
 
@@ -74,7 +74,7 @@ describe('babel plugin', () => {
     expect(output?.code).toMatchInlineSnapshot(`
       "import React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
-      <><Style hash=\\"css-2lhdif\\">{[\\".css-1iqe21w{font-size:12px;}\\"]}</Style><div className={\\"css-1iqe21w\\"} /></>;"
+      <><Style hash=\\"cc-31m7m\\">{[\\".cc-1iqe21w{font-size:12px;}\\"]}</Style><div className={\\"cc-1iqe21w\\"} /></>;"
     `);
   });
 });

--- a/packages/ts-transform/src/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/__tests__/index.test.tsx
@@ -138,7 +138,7 @@ describe('root transformer', () => {
     expect(actual.outputText).toMatchInlineSnapshot(`
       "import React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
-      React.forwardRef(({ as: C = \\"div\\", ...props }, ref) => <><Style hash=\\"css-1x3e11p\\">{[\\".css-1x3e11p{font-size:12px;}\\"]}</Style><C {...props} ref={ref} className={\\"css-1x3e11p\\" + (props.className ? \\" \\" + props.className : \\"\\")}/></>);
+      React.forwardRef(({ as: C = \\"div\\", ...props }, ref) => <><Style hash=\\"cc-1x3e11p\\">{[\\".cc-1x3e11p{font-size:12px;}\\"]}</Style><C {...props} ref={ref} className={\\"cc-1x3e11p\\" + (props.className ? \\" \\" + props.className : \\"\\")}/></>);
       "
     `);
   });
@@ -158,7 +158,7 @@ describe('root transformer', () => {
     expect(actual.outputText).toMatchInlineSnapshot(`
       "import React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
-      <><Style hash=\\"css-1iqe21w\\">{[\\".css-1iqe21w{font-size:12px;}\\"]}</Style><div className=\\"css-1iqe21w\\"/></>;
+      <><Style hash=\\"cc-1iqe21w\\">{[\\".cc-1iqe21w{font-size:12px;}\\"]}</Style><div className=\\"cc-1iqe21w\\"/></>;
       "
     `);
   });
@@ -180,7 +180,7 @@ describe('root transformer', () => {
     expect(actual.outputText).toMatchInlineSnapshot(`
       "import React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
-      <><Style hash=\\"css-2lhdif\\">{[\\".css-1iqe21w{font-size:12px;}\\"]}</Style><div className={\\"css-1iqe21w\\"}/></>;
+      <><Style hash=\\"cc-31m7m\\">{[\\".cc-1iqe21w{font-size:12px;}\\"]}</Style><div className={\\"cc-1iqe21w\\"}/></>;
       "
     `);
   });

--- a/packages/ts-transform/src/constants.tsx
+++ b/packages/ts-transform/src/constants.tsx
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 
 // Strings
-export const CLASS_NAME_PREFIX = 'css';
+export const CLASS_NAME_PREFIX = 'cc';
 export const CSS_VARIABLE_PREFIX = 'var';
 
 // Props


### PR DESCRIPTION
CSS hash now doesn't use the same prefix as emotion. Closes #131

Previous generated css hash — `.css-xxxx {}`
Now — `.cc-xxxx {}`