### PR TITLE
refactor: jest matcher now supports multiple style tags

### DIFF
--- a/packages/jest/src/__tests__/matchers.test.tsx
+++ b/packages/jest/src/__tests__/matchers.test.tsx
@@ -1,57 +1,88 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import '@compiled/css-in-js';
+import { styled } from '@compiled/css-in-js';
 
-it('should detect styles', () => {
-  const { getByText } = render(
-    <div
-      css={{
-        fontSize: '12px',
-      }}>
-      hello world
-    </div>
-  );
-
-  expect(getByText('hello world')).toHaveCompiledCss('font-size', '12px');
-});
-
-it('should detect missing styles', () => {
-  const { getByText } = render(<div css={{ fontSize: '12px' }}>hello world</div>);
-
-  expect(getByText('hello world')).not.toHaveCompiledCss('color', 'blue');
-});
-
-it('should detect multiple styles', () => {
-  const { getByText } = render(<div css={{ fontSize: '12px', color: 'blue' }}>hello world</div>);
-
-  expect(getByText('hello world')).toHaveCompiledCss({
-    fontSize: '12px',
-    color: 'blue',
+describe('toHaveCompliedCss', () => {
+  afterEach(() => {
+    document.getElementsByTagName('html')[0].innerHTML = '';
   });
-});
 
-it('should detect single missing styles', () => {
-  const { getByText } = render(<div css={{ fontSize: '12px', color: 'blue' }}>hello world</div>);
+  it('should detect styles', () => {
+    const { getByText } = render(
+      <div
+        css={{
+          fontSize: '12px',
+        }}>
+        hello world
+      </div>
+    );
 
-  expect(getByText('hello world')).not.toHaveCompiledCss({
-    zindex: '9999',
+    expect(getByText('hello world')).toHaveCompiledCss('font-size', '12px');
   });
-});
 
-it('should detect multiple missing styles', () => {
-  const { getByText } = render(<div css={{ fontSize: '12px', color: 'blue' }}>hello world</div>);
+  it('should detect missing styles', () => {
+    const { getByText } = render(<div css={{ fontSize: '12px' }}>hello world</div>);
 
-  expect(getByText('hello world')).not.toHaveCompiledCss({
-    backgroundColor: 'yellow',
-    zindex: '9999',
+    expect(getByText('hello world')).not.toHaveCompiledCss('color', 'blue');
   });
-});
 
-it('should detect evaluated rule from array styles', () => {
-  const base = { fontSize: 12 };
-  const next = ` font-size: 15px; `;
+  it('should detect multiple styles', () => {
+    const { getByText } = render(<div css={{ fontSize: '12px', color: 'blue' }}>hello world</div>);
 
-  const { getByText } = render(<div css={[base, next]}>hello world</div>);
-  expect(getByText('hello world')).toHaveCompiledCss('font-size', '15px');
-  expect(getByText('hello world')).toHaveCompiledCss('font-size', '12px');
+    expect(getByText('hello world')).toHaveCompiledCss({
+      fontSize: '12px',
+      color: 'blue',
+    });
+  });
+
+  it('should detect single missing styles', () => {
+    const { getByText } = render(<div css={{ fontSize: '12px', color: 'blue' }}>hello world</div>);
+
+    expect(getByText('hello world')).not.toHaveCompiledCss({
+      zindex: '9999',
+    });
+  });
+
+  it('should detect multiple missing styles', () => {
+    const { getByText } = render(<div css={{ fontSize: '12px', color: 'blue' }}>hello world</div>);
+
+    expect(getByText('hello world')).not.toHaveCompiledCss({
+      backgroundColor: 'yellow',
+      zindex: '9999',
+    });
+  });
+
+  it('should detect evaluated rule from array styles', () => {
+    const base = { fontSize: 12 };
+    const next = ` font-size: 15px; `;
+
+    const { getByText } = render(<div css={[base, next]}>hello world</div>);
+    expect(getByText('hello world')).toHaveCompiledCss('font-size', '15px');
+    expect(getByText('hello world')).toHaveCompiledCss('font-size', '12px');
+  });
+
+  it('should find styles composed from multiple sources', () => {
+    const StyledDiv = styled.div`
+      font-size: 12px;
+    `;
+
+    const { getByText } = render(<StyledDiv css={{ fontSize: 14 }}>Hello world</StyledDiv>);
+
+    expect(getByText('Hello world')).toHaveCompiledCss('font-size', '12px');
+    expect(getByText('Hello world')).toHaveCompiledCss('font-size', '14px');
+  });
+
+  it('should find multiple styles composed from multiple sources', () => {
+    const StyledDiv = styled.div`
+      color: yellow;
+      background-color: red;
+    `;
+
+    const { getByText } = render(<StyledDiv css={{ color: 'blue' }}>Hello world</StyledDiv>);
+
+    expect(getByText('Hello world')).toHaveCompiledCss({
+      backgroundColor: 'red',
+      color: 'blue',
+    });
+  });
 });

--- a/packages/jest/src/__tests__/matchers.test.tsx
+++ b/packages/jest/src/__tests__/matchers.test.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import '@compiled/css-in-js';
+
+it('should detect styles', () => {
+  const { getByText } = render(
+    <div
+      css={{
+        fontSize: '12px',
+      }}>
+      hello world
+    </div>
+  );
+
+  expect(getByText('hello world')).toHaveCompiledCss('font-size', '12px');
+});
+
+it('should detect missing styles', () => {
+  const { getByText } = render(<div css={{ fontSize: '12px' }}>hello world</div>);
+
+  expect(getByText('hello world')).not.toHaveCompiledCss('color', 'blue');
+});
+
+it('should detect multiple styles', () => {
+  const { getByText } = render(<div css={{ fontSize: '12px', color: 'blue' }}>hello world</div>);
+
+  expect(getByText('hello world')).toHaveCompiledCss({
+    fontSize: '12px',
+    color: 'blue',
+  });
+});
+
+it('should detect single missing styles', () => {
+  const { getByText } = render(<div css={{ fontSize: '12px', color: 'blue' }}>hello world</div>);
+
+  expect(getByText('hello world')).not.toHaveCompiledCss({
+    zindex: '9999',
+  });
+});
+
+it('should detect multiple missing styles', () => {
+  const { getByText } = render(<div css={{ fontSize: '12px', color: 'blue' }}>hello world</div>);
+
+  expect(getByText('hello world')).not.toHaveCompiledCss({
+    backgroundColor: 'yellow',
+    zindex: '9999',
+  });
+});
+
+it('should detect evaluated rule from array styles', () => {
+  const base = { fontSize: 12 };
+  const next = ` font-size: 15px; `;
+
+  const { getByText } = render(<div css={[base, next]}>hello world</div>);
+  expect(getByText('hello world')).toHaveCompiledCss('font-size', '15px');
+  expect(getByText('hello world')).toHaveCompiledCss('font-size', '12px');
+});

--- a/packages/jest/src/matchers.tsx
+++ b/packages/jest/src/matchers.tsx
@@ -4,6 +4,17 @@ const kebabCase = (str: string) =>
     .replace(/\s+/g, '-')
     .toLowerCase();
 
+const mapProperties = (properties: Record<string, any>) =>
+  Object.keys(properties).map(property => `${kebabCase(property)}:${properties[property]}`);
+
+const getMountedProperties = () =>
+  Array.from(document.styleSheets)
+    .map(sheet =>
+      // @ts-ignore
+      sheet.cssRules.map((rule: CSSRule) => rule.style.cssText)
+    )
+    .join(' ');
+
 export function toHaveCompiledCss(
   this: jest.MatcherUtils,
   element: HTMLElement,
@@ -11,77 +22,56 @@ export function toHaveCompiledCss(
 ): jest.CustomMatcherResult {
   const [property, value] = args;
   const properties = typeof property === 'string' ? { [property]: value } : property;
-  let styleElement = element.parentElement && element.parentElement.querySelector('style');
+  const inlineStyleTag = element.parentElement && element.parentElement.querySelector('style');
+  const styleElements: HTMLStyleElement[] =
+    inlineStyleTag != null ? [inlineStyleTag] : Array.from(document.head.querySelectorAll('style'));
 
-  if (!styleElement) {
-    // There wasn't a style element found within - let's check the head for it instead.
-    const styleElements = Array.from(document.head.querySelectorAll('style'));
-    for (const tag of styleElements) {
-      if (tag.innerHTML.includes(element.className)) {
-        styleElement = tag as HTMLStyleElement;
-        break;
-      }
-    }
-  }
-
-  if (!styleElement) {
+  if (!styleElements) {
     return {
       pass: false,
       message: () => 'pairing style element was not found',
     };
   }
 
-  // This is a hack to get ahold of the styles.
-  // Unfortunately JSDOM doesn't handle css variables properly
-  // See: https://github.com/jsdom/jsdom/issues/1895
-  // @ts-ignore
-  const styles = element[Object.keys(element)[0]].memoizedProps.style;
-  let css = styleElement.textContent || '';
+  const stylesToFind = mapProperties(properties);
+  const foundStyles: string[] = [];
 
-  if (styles && Object.keys(styles).length > 0) {
-    Object.entries(styles).forEach(([key, value]: [string, any]) => {
-      // Replace all instances of var with the value.
-      // We split and join to replace all instances without needing to jump into a dynamic regex.
-      css = css.split(`var(${key})`).join(value);
-    });
+  for (const styleElement of styleElements) {
+    let css = styleElement.textContent || '';
+    // This is a hack to get ahold of the styles.
+    // Unfortunately JSDOM doesn't handle css variables properly
+    // See: https://github.com/jsdom/jsdom/issues/1895
+    // @ts-ignore
+    const styles = element[Object.keys(element)[0]].memoizedProps.style;
+
+    if (styles && Object.keys(styles).length > 0) {
+      Object.entries(styles).forEach(([key, value]: [string, any]) => {
+        // Replace all instances of var with the value.
+        // We split and join to replace all instances without needing to jump into a dynamic regex.
+        css = css.split(`var(${key})`).join(value);
+      });
+    }
+
+    foundStyles.push(...stylesToFind.filter(styleToFind => css.includes(styleToFind)));
   }
 
-  const stylesToFind = Object.keys(properties).map(
-    property => `${kebabCase(property)}:${properties[property]}`
-  );
-  const foundStyles = stylesToFind.filter(styleToFind => css.includes(styleToFind));
-  const notFoundStyles = stylesToFind.filter(styleToFind => !css.includes(styleToFind));
-  const includedSelector = css.includes(`.${element.className}`);
+  const notFoundStyles = stylesToFind.filter(style => !foundStyles.includes(style));
+  const foundFormatted = stylesToFind.join(', ');
+  const notFoundFormatted = notFoundStyles.join(', ');
 
-  if (includedSelector && foundStyles.length > 0 && notFoundStyles.length === 0) {
+  if (foundStyles.length > 0 && notFoundStyles.length === 0) {
     return {
       pass: true,
       message: !this.isNot
         ? () => ''
-        : () => `Found "${foundStyles.join(', ')}" on <${element.nodeName.toLowerCase()} ${styles &&
-            `style={${JSON.stringify(styles)}}`}> element.
-
-  Reconciled css (css variables replaced with actual values):
-  ${css}
-
-  Original css:
-  ${(styleElement && styleElement.textContent) || ''}
-  `,
+        : () =>
+            `Found "${foundFormatted}" on <${element.nodeName.toLowerCase()} css={\`${getMountedProperties()}\`}> element.`,
     };
   }
 
   return {
     pass: false,
-    message: () => `Could not find "${notFoundStyles.join(
-      ', '
-    )}" on <${element.nodeName.toLowerCase()} ${styles &&
-      `style={${JSON.stringify(styles)}}`}> element.
-
-Reconciled css (css variables replaced with actual values):
-${css}
-
-Original css:
-${(styleElement && styleElement.textContent) || ''}
-`,
+    message: () =>
+      `Could not find "${notFoundFormatted}" on <${element.nodeName.toLowerCase()} css={\`${getMountedProperties()}\`}> element.`,
   };
 }

--- a/packages/jest/src/matchers.tsx
+++ b/packages/jest/src/matchers.tsx
@@ -15,6 +15,9 @@ const getMountedProperties = () =>
     )
     .join(' ');
 
+const containsClassNames = (classNames: string[], css: string) =>
+  classNames.reduce((accum, className) => (css.includes(`.${className}`) ? true : accum), false);
+
 export function toHaveCompiledCss(
   this: jest.MatcherUtils,
   element: HTMLElement,
@@ -35,6 +38,7 @@ export function toHaveCompiledCss(
 
   const stylesToFind = mapProperties(properties);
   const foundStyles: string[] = [];
+  const classNames = element.className.split(' ');
 
   for (const styleElement of styleElements) {
     let css = styleElement.textContent || '';
@@ -52,7 +56,9 @@ export function toHaveCompiledCss(
       });
     }
 
-    foundStyles.push(...stylesToFind.filter(styleToFind => css.includes(styleToFind)));
+    if (containsClassNames(classNames, css)) {
+      foundStyles.push(...stylesToFind.filter(styleToFind => css.includes(styleToFind)));
+    }
   }
 
   const notFoundStyles = stylesToFind.filter(style => !foundStyles.includes(style));


### PR DESCRIPTION
Closes: #120 

Styles coming from multiple sources are added to the head as separate style elements to the head.
This PR adds support for multiple style elements and class names. If we are seeking properties from two separate sources (css prop and styled api) the matcher is now able to pick it up. 

Bonus: we're now able to output all mounted css properties in the error message. 
  
![image](https://user-images.githubusercontent.com/3030010/79528218-c1a88b00-80ac-11ea-896f-d0623f7709a8.png)
