### PR TITLE
[Blocked] Use React namespace import instead of default import

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ styled.div`
 ### `ClassNames` component
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import { ClassNames } from '@compiled/css-in-js';
 
 <ClassNames>{({ css }) => <div className={css({ fontSize: 12 })} />}</ClassNames>;

--- a/examples/class-names-static-object.tsx
+++ b/examples/class-names-static-object.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { ClassNames } from '@compiled/css-in-js';
 
 export default {

--- a/examples/css-prop-static-object.tsx
+++ b/examples/css-prop-static-object.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import '@compiled/css-in-js';
 import { hover } from './mixins/mixins';
 

--- a/examples/media-queries.tsx
+++ b/examples/media-queries.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { styled } from '@compiled/css-in-js';
 
 export default {

--- a/examples/perf-compare.tsx
+++ b/examples/perf-compare.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import * as CompiledStyled from './libs/compiled-styled';
 import * as EmotionStyled from './libs/emotion-styled';
 import * as StyledComponents from './libs/styled-components';

--- a/examples/styled-static-object.tsx
+++ b/examples/styled-static-object.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { styled } from '@compiled/css-in-js';
 
 export default {

--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -36,7 +36,7 @@ describe('babel plugin', () => {
     );
 
     expect(output?.code).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       React.forwardRef(({
         as: C = \\"div\\",
@@ -58,7 +58,7 @@ describe('babel plugin', () => {
     );
 
     expect(output?.code).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       React.forwardRef(({
         as: C = \\"div\\",
@@ -70,7 +70,7 @@ describe('babel plugin', () => {
   it('should transform css prop', () => {
     const output = transformSync(
       `
-      import React from 'react';
+      import * as React from 'react';
       import '@compiled/css-in-js';
 
       <div css={{ fontSize: 12 }} />
@@ -79,7 +79,7 @@ describe('babel plugin', () => {
     );
 
     expect(output?.code).toMatchInlineSnapshot(`
-      "import React from 'react';
+      "import * as React from 'react';
       import { Style } from '@compiled/css-in-js';
       <><Style hash=\\"1iqe21w\\">{[\\".cc-1iqe21w{font-size:12px;}\\"]}</Style><div className=\\"cc-1iqe21w\\" /></>;"
     `);
@@ -98,7 +98,7 @@ describe('babel plugin', () => {
     );
 
     expect(output?.code).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       <><Style hash=\\"31m7m\\">{[\\".cc-1iqe21w{font-size:12px;}\\"]}</Style><div className={\\"cc-1iqe21w\\"} /></>;"
     `);

--- a/packages/css-in-js/src/class-names/__tests__/index.test.tsx
+++ b/packages/css-in-js/src/class-names/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import React from 'react';
+import * as React from 'react';
 import { ClassNames } from '@compiled/css-in-js';
 import '@compiled/jest-css-in-js';
 

--- a/packages/css-in-js/src/jsx/__tests__/index.test.tsx
+++ b/packages/css-in-js/src/jsx/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import '@compiled/css-in-js';
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 
 describe('css prop', () => {

--- a/packages/css-in-js/src/styled/__tests__/index.test.tsx
+++ b/packages/css-in-js/src/styled/__tests__/index.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import React from 'react';
+import * as React from 'react';
 import { styled } from '@compiled/css-in-js';
 import { em } from 'polished';
 

--- a/packages/jest/src/__tests__/matchers.test.tsx
+++ b/packages/jest/src/__tests__/matchers.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import React from 'react';
+import * as React from 'react';
 import { styled } from '@compiled/css-in-js';
 
 describe('toHaveCompliedCss', () => {

--- a/packages/style/src/__tests__/style-ssr.test.tsx
+++ b/packages/style/src/__tests__/style-ssr.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import React from 'react';
+import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import 'jest-extended';
 import Style from '../style';

--- a/packages/style/src/__tests__/style.test.tsx
+++ b/packages/style/src/__tests__/style.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { render } from '@testing-library/react';
 import 'jest-extended';
 import Style from '../style';

--- a/packages/style/src/style.tsx
+++ b/packages/style/src/style.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { createStyleSheet } from './sheet';
 import { analyzeCssInDev } from './dev-warnings';
 import { StyleSheetOpts } from './types';

--- a/packages/ts-transform/src/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/__tests__/index.test.tsx
@@ -30,7 +30,7 @@ describe('root transformer', () => {
       ts.transpileModule(
         `
           import '@compiled/css-in-js';
-          import React from 'react';
+          import * as React from 'react';
           const MyComponent = () => <div css={{ fontSize: '20px' }}>hello world</div>
         `,
         createTsConfig(transformer)
@@ -45,7 +45,7 @@ describe('root transformer', () => {
       ts.transpileModule(
         `
           import '@compiled/css-in-js';
-          import React from 'react';
+          import * as React from 'react';
           var MyComponent = () => <div css={{ fontSize: '20px' }}>hello world</div>
         `,
         createTsConfig(transformer)
@@ -66,7 +66,7 @@ describe('root transformer', () => {
     expect(() => {
       transformer.transform(`
         import '@compiled/css-in-js';
-        import React from 'react';
+        import * as React from 'react';
         import { mixin } from './mixins';
 
         <div css={{ ':hover': mixin }}>hello</div>
@@ -86,7 +86,7 @@ describe('root transformer', () => {
     );
 
     expect(actual.outputText).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       <><Style hash=\\"1b1wq3m\\">{[\\".cc-1b1wq3m{font-size:20px;}\\\\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1vZHVsZS50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRVEiLCJmaWxlIjoibW9kdWxlLnRzeCIsInNvdXJjZXNDb250ZW50IjpbIlxuICAgICAgICBpbXBvcnQgJ0Bjb21waWxlZC9jc3MtaW4tanMnO1xuICAgICAgICA8ZGl2IGNzcz17eyBmb250U2l6ZTogJzIwcHgnIH19PmhlbGxvIHdvcmxkPC9kaXY+XG4gICAgICAiXX0= */\\"]}</Style><div className=\\"cc-1b1wq3m\\">hello world</div></>;
       "
@@ -106,7 +106,7 @@ describe('root transformer', () => {
     );
 
     expect(actual.outputText).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       React.forwardRef(({ as: C = \\"div\\", ...props }, ref) => <><Style hash=\\"1b1wq3m\\">{[\\".cc-1b1wq3m{font-size:20px;}\\\\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1vZHVsZS50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR1EiLCJmaWxlIjoibW9kdWxlLnRzeCIsInNvdXJjZXNDb250ZW50IjpbIlxuICAgICAgICBpbXBvcnQgeyBzdHlsZWQgfSBmcm9tICdAY29tcGlsZWQvY3NzLWluLWpzJztcblxuICAgICAgICBzdHlsZWQuZGl2KHsgZm9udFNpemU6IDIwIH0pO1xuICAgICAgIl19 */\\"]}</Style><C {...props} ref={ref} className={\\"cc-1b1wq3m\\" + (props.className ? \\" \\" + props.className : \\"\\")}/></>);
       "
@@ -126,7 +126,7 @@ describe('root transformer', () => {
     );
 
     expect(actual.outputText).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       <><Style hash=\\"gpurwr\\">{[\\".cc-1b1wq3m{font-size:20px;}\\\\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1vZHVsZS50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR1EiLCJmaWxlIjoibW9kdWxlLnRzeCIsInNvdXJjZXNDb250ZW50IjpbIlxuICAgICAgICBpbXBvcnQgeyBDbGFzc05hbWVzIH0gZnJvbSAnQGNvbXBpbGVkL2Nzcy1pbi1qcyc7XG5cbiAgICAgICAgPENsYXNzTmFtZXM+eyh7IGNzcyB9KSA9PiA8ZGl2IGNsYXNzTmFtZT17Y3NzKHsgZm9udFNpemU6IDIwIH0pfSAvPn08L0NsYXNzTmFtZXM+XG4gICAgICAiXX0= */\\"]}</Style><div className={\\"cc-1b1wq3m\\"}/></>;
       "
@@ -196,7 +196,7 @@ describe('root transformer', () => {
     );
 
     expect(actual.outputText).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       React.forwardRef(({ as: C = \\"div\\", ...props }, ref) => <><Style hash=\\"1x3e11p\\">{[\\".cc-1x3e11p{font-size:12px;}\\"]}</Style><C {...props} ref={ref} className={\\"cc-1x3e11p\\" + (props.className ? \\" \\" + props.className : \\"\\")}/></>);
       "
@@ -216,7 +216,7 @@ describe('root transformer', () => {
     );
 
     expect(actual.outputText).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       <><Style hash=\\"1iqe21w\\">{[\\".cc-1iqe21w{font-size:12px;}\\"]}</Style><div className=\\"cc-1iqe21w\\"/></>;
       "
@@ -238,7 +238,7 @@ describe('root transformer', () => {
     );
 
     expect(actual.outputText).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       <><Style hash=\\"31m7m\\">{[\\".cc-1iqe21w{font-size:12px;}\\"]}</Style><div className={\\"cc-1iqe21w\\"}/></>;
       "

--- a/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
@@ -24,7 +24,7 @@ describe('styled component transformer', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       const ListItem = React.forwardRef(({ as: C = \\"div\\", ...props }, ref) => <><Style hash=\\"css-test\\">{[\\".css-test{font-size:20px;}\\"]}</Style><C {...props} ref={ref} className={\\"css-test\\" + (props.className ? \\" \\" + props.className : \\"\\")}/></>);
       if (process.env.NODE_ENV === \\"development\\") {
@@ -108,7 +108,7 @@ describe('styled component transformer', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import React from \\"react\\";
+      "import * as React from \\"react\\";
       import { Style } from '@compiled/css-in-js';
       const ListItem = React.forwardRef(({ as: C = \\"div\\", ...props }, ref) => <><Style hash=\\"css-test\\">{[\\".css-test{font-size:20px;}\\"]}</Style><C {...props} ref={ref} className={\\"css-test\\" + (props.className ? \\" \\" + props.className : \\"\\")}/></>);
       if (process.env.NODE_ENV === \\"development\\") {
@@ -165,21 +165,22 @@ describe('styled component transformer', () => {
     expect(actual).toInclude('ListItem.displayName = "ListItem";');
   });
 
-  it('should do nothing if react default import is already defined', () => {
+  it.only('should do nothing if react namespace import is already defined', () => {
     const actual = transformer.transform(`
-      import React from 'react';
+      import * as React from 'react';
       import { styled } from '@compiled/css-in-js';
+
       const ListItem = styled.div\`
         font-size: 20px;
       \`;
     `);
 
-    expect(actual).toInclude("import React from 'react';");
+    expect(actual).toInclude("import * as React from 'react';");
   });
 
   it('should compose a component using template literal', () => {
     const actual = transformer.transform(`
-      import React from 'react';
+      import * as React from 'react';
       import { styled } from '@compiled/css-in-js';
 
       const Component = () => null;
@@ -194,7 +195,7 @@ describe('styled component transformer', () => {
 
   it('should compose a component using object literal', () => {
     const actual = transformer.transform(`
-      import React from 'react';
+      import * as React from 'react';
       import { styled } from '@compiled/css-in-js';
 
       const Component = () => null;


### PR DESCRIPTION
```
git clone git@github.com:atlassian-labs/compiled-css-in-js.git
git checkout react-namespace-import
yarn
yarn test packages/ts-transform/src/styled-component/__tests__/index.test.tsx --watch
```

---

Unfortunately this is blocked because if we move to namespace imports the TypeScript compiler just gets rid of the imports.

I've targetted one test with `.only` that shows this behaviour happening.

Links:
https://github.com/microsoft/TypeScript/issues/14419#issuecomment-568679625
https://github.com/microsoft/TypeScript/issues/34547
