### PR TITLE
fix: fixes string literal interpolations being buggy

### DIFF
--- a/packages/ts-transform/src/class-names/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/class-names/__tests__/index.test.tsx
@@ -129,7 +129,7 @@ describe('class names transformer', () => {
 
         const ListItem = () => (
           <ClassNames>
-            {({ css, style }) => <div style={style} className={css\`font-size \${fontSize}px;\`}>hello, world!</div>}
+            {({ css, style }) => <div style={style} className={css\`font-size: \${fontSize}px;\`}>hello, world!</div>}
           </ClassNames>
         );
       `);

--- a/packages/ts-transform/src/class-names/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/class-names/__tests__/index.test.tsx
@@ -121,7 +121,7 @@ describe('class names transformer', () => {
   });
 
   describe('using a string literal', () => {
-    it('should persist suffix of dynamic property value into inline styles', () => {
+    it('should move suffix of interpolation into inline styles', () => {
       const actual = transformer.transform(`
         import { ClassNames } from '@compiled/css-in-js';
 

--- a/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
@@ -564,7 +564,7 @@ describe('css prop transformer', () => {
       expect(actual).toInclude('style={{ "--var-test": primary }}');
     });
 
-    it.only('should allow multiple interpolations inside a single css property', () => {
+    it('should allow multiple interpolations inside a single css property', () => {
       const actual = transformer.transform(`
         import React from 'react';
         import '@compiled/css-in-js';
@@ -581,8 +581,10 @@ describe('css prop transformer', () => {
         </div>
       `);
 
-      expect(actual).toInclude('transform:translate3d(var(--var-test), var(--var-test))');
       expect(actual).toInclude('style={{ "--var-test": x + "px", "--var-test": y }}');
+      expect(actual).toInclude(
+        '.css-test{-webkit-transform:translate3d(var(--var-test),var(--var-test),0);-ms-transform:translate3d(var(--var-test),var(--var-test),0);transform:translate3d(var(--var-test),var(--var-test),0);}'
+      );
     });
 
     xit('should transform template string with argument arrow function import', () => {

--- a/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
@@ -564,6 +564,27 @@ describe('css prop transformer', () => {
       expect(actual).toInclude('style={{ "--var-test": primary }}');
     });
 
+    it('should allow multiple interpolations inside a single css property', () => {
+      const actual = transformer.transform(`
+        import React from 'react';
+        import '@compiled/css-in-js';
+
+        const x = 1;
+        const y = '2px';
+
+        <div
+          css={\`
+            transform: translate3d(\${x}px, $\{y}, 0);
+          \`}
+        >
+          hello world
+        </div>
+      `);
+
+      expect(actual).toInclude('transform:translate3d(var(--var-test), var(--var-test))');
+      expect(actual).toInclude('style={{ "--var-test": x + "px", "--var-test": y }}');
+    });
+
     xit('should transform template string with argument arrow function import', () => {
       const actual = transformer.addSource({
         path: '/mixy-in.ts',

--- a/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
@@ -564,7 +564,7 @@ describe('css prop transformer', () => {
       expect(actual).toInclude('style={{ "--var-test": primary }}');
     });
 
-    it('should allow multiple interpolations inside a single css property', () => {
+    it.only('should allow multiple interpolations inside a single css property', () => {
       const actual = transformer.transform(`
         import React from 'react';
         import '@compiled/css-in-js';

--- a/packages/ts-transform/src/utils/__tests__/string-iterpolations.test.tsx
+++ b/packages/ts-transform/src/utils/__tests__/string-iterpolations.test.tsx
@@ -1,4 +1,4 @@
-import { cssBeforeInterpolation, cssAfterInterpolation } from '../template-literal-to-css';
+import { cssBeforeInterpolation, cssAfterInterpolation } from '../string-interpolations';
 
 describe('template literal to css', () => {
   describe('interpolations with surrounding css', () => {
@@ -96,6 +96,83 @@ describe('template literal to css', () => {
       expect(before.css).toEqual('\n            transform: translate3d(var(--var-test), ');
       expect(after.variableSuffix).toEqual('');
       expect(after.css).toEqual(', 0);');
+    });
+  });
+
+  describe('interpolations with multiple groups', () => {
+    it('should extract the first part of the first group', () => {
+      const parts = [
+        'background-image: linear-gradient(45deg, ',
+        ' 25%, transparent 25%),',
+        'linear-gradient(-45deg, ',
+        ' 25%, transparent 25%),',
+        'linear-gradient(45deg, transparent 75%, ',
+        ' 75%),',
+        'linear-gradient(-45deg, transparent 75%, ',
+        ' 75%);',
+      ];
+
+      const before = cssBeforeInterpolation(parts[0]);
+      const after = cssAfterInterpolation(parts[1]);
+
+      expect(before.css).toEqual(parts[0]);
+      expect(before.variablePrefix).toEqual(undefined);
+      expect(after.variableSuffix).toEqual('');
+      expect(after.css).toEqual(parts[1]);
+    });
+
+    it('should extract the first part of the second group', () => {
+      const parts = [
+        'background-image: linear-gradient(45deg, var(--var-test) 25%, transparent 25%),',
+        'linear-gradient(-45deg, ',
+        ' 25%, transparent 25%),',
+        'linear-gradient(45deg, transparent 75%, ',
+        ' 75%),',
+        'linear-gradient(-45deg, transparent 75%, ',
+        ' 75%);',
+      ];
+
+      const before = cssBeforeInterpolation(parts[0]);
+      const after = cssAfterInterpolation(parts[1]);
+
+      expect(before.css).toEqual(parts[0]);
+      expect(before.variablePrefix).toEqual(undefined);
+      expect(after.css).toEqual(parts[1]);
+      expect(after.variableSuffix).toEqual('');
+    });
+
+    it('should extract the first part of the third group', () => {
+      const parts = [
+        'background-image: linear-gradient(45deg, var(--var-test) 25%, transparent 25%), linear-gradient(-45deg, var(--var-test) 25%, transparent 25%),',
+        'linear-gradient(45deg, transparent 75%, ',
+        ' 75%),',
+        'linear-gradient(-45deg, transparent 75%, ',
+        ' 75%);',
+      ];
+
+      const before = cssBeforeInterpolation(parts[0]);
+      const after = cssAfterInterpolation(parts[1]);
+
+      expect(before.css).toEqual(parts[0]);
+      expect(before.variablePrefix).toEqual(undefined);
+      expect(after.css).toEqual(parts[1]);
+      expect(after.variableSuffix).toEqual('');
+    });
+
+    it('should extract the first part of the fourth group', () => {
+      const parts = [
+        'background-image: linear-gradient(45deg, var(--var-test) 25%, transparent 25%), linear-gradient(-45deg, var(--var-test) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, var(--var-test) 75%),',
+        'linear-gradient(-45deg, transparent 75%, ',
+        ' 75%);',
+      ];
+
+      const before = cssBeforeInterpolation(parts[0]);
+      const after = cssAfterInterpolation(parts[1]);
+
+      expect(before.css).toEqual(parts[0]);
+      expect(before.variablePrefix).toEqual(undefined);
+      expect(after.css).toEqual(parts[1]);
+      expect(after.variableSuffix).toEqual('');
     });
   });
 

--- a/packages/ts-transform/src/utils/__tests__/template-literal-to-css.test.tsx
+++ b/packages/ts-transform/src/utils/__tests__/template-literal-to-css.test.tsx
@@ -5,73 +5,108 @@ describe('template literal to css', () => {
     it('should extract the prefix of a simple template literal', () => {
       const simpleParts = ['content: "', '";font-color:blue;'];
 
-      const head = cssBeforeInterpolation(simpleParts[0]);
+      const extract = cssBeforeInterpolation(simpleParts[0]);
 
-      expect(head.variablePrefix).toEqual('"');
-      expect(head.css).toEqual('content: ');
+      expect(extract.variablePrefix).toEqual('"');
+      expect(extract.css).toEqual('content: ');
     });
 
     it('should extract the suffix of a simple template literal', () => {
       const simpleParts = ['content: "', '";font-color:blue;'];
 
-      const head = cssAfterInterpolation(simpleParts[1]);
+      const extract = cssAfterInterpolation(simpleParts[1]);
 
-      expect(head.variableSuffix).toEqual('"');
-      expect(head.css).toEqual(';font-color:blue;');
+      expect(extract.variableSuffix).toEqual('"');
+      expect(extract.css).toEqual(';font-color:blue;');
     });
 
     it('should extract the prefix of a complex template literal', () => {
       const complexParts = ['transform: translateX(', ');color:blue;'];
 
-      const head = cssBeforeInterpolation(complexParts[0]);
+      const extract = cssBeforeInterpolation(complexParts[0]);
 
-      expect(head.variablePrefix).toEqual(undefined);
-      expect(head.css).toEqual('transform: translateX(');
+      expect(extract.variablePrefix).toEqual(undefined);
+      expect(extract.css).toEqual('transform: translateX(');
     });
 
     it('should extract the suffix of a complex template literal', () => {
       const complexParts = ['transform: translateX(', ');color:blue;'];
 
-      const head = cssAfterInterpolation(complexParts[1]);
+      const extract = cssAfterInterpolation(complexParts[1]);
 
-      expect(head.variableSuffix).toEqual('');
-      expect(head.css).toEqual(');color:blue;');
+      expect(extract.variableSuffix).toEqual('');
+      expect(extract.css).toEqual(');color:blue;');
     });
 
     it('should extract first part of a three part value', () => {
       const complexPartsNoPropertyName = ['transform: transform3d(', ', ', ')'];
 
-      const head = cssBeforeInterpolation(complexPartsNoPropertyName[0]);
+      const extract = cssBeforeInterpolation(complexPartsNoPropertyName[0]);
 
-      expect(head.variablePrefix).toEqual(undefined);
-      expect(head.css).toEqual('transform: transform3d(');
+      expect(extract.variablePrefix).toEqual(undefined);
+      expect(extract.css).toEqual('transform: transform3d(');
     });
 
     it('should extract before second part of a three part value', () => {
       const complexPartsNoPropertyName = ['transform: transform3d(', ', ', ')'];
 
-      const head = cssBeforeInterpolation(complexPartsNoPropertyName[1]);
+      const extract = cssBeforeInterpolation(complexPartsNoPropertyName[1]);
 
-      expect(head.variablePrefix).toEqual(undefined);
-      expect(head.css).toEqual(', ');
+      expect(extract.variablePrefix).toEqual(undefined);
+      expect(extract.css).toEqual(', ');
     });
 
     it('should extract after second part of a three part value', () => {
       const complexPartsNoPropertyName = ['transform: transform3d(', ', ', ')'];
 
-      const head = cssAfterInterpolation(complexPartsNoPropertyName[1]);
+      const extract = cssAfterInterpolation(complexPartsNoPropertyName[1]);
 
-      expect(head.variableSuffix).toEqual('');
-      expect(head.css).toEqual(', ');
+      expect(extract.variableSuffix).toEqual('');
+      expect(extract.css).toEqual(', ');
     });
 
     it('should extract second part of a three part value', () => {
       const complexPartsNoPropertyName = ['transform: transform3d(', ', ', ')'];
 
-      const head = cssAfterInterpolation(complexPartsNoPropertyName[2]);
+      const extract = cssAfterInterpolation(complexPartsNoPropertyName[2]);
 
-      expect(head.variableSuffix).toEqual('');
-      expect(head.css).toEqual(')');
+      expect(extract.variableSuffix).toEqual('');
+      expect(extract.css).toEqual(')');
+    });
+
+    it('should get the before and after for the first part of a transform interpolation', () => {
+      const css = [
+        `
+        transform: translate3d(
+      `,
+        `px, `,
+        `, 0);`,
+      ];
+
+      const before = cssBeforeInterpolation(css[0]);
+      const after = cssAfterInterpolation(css[1]);
+
+      expect(before.variablePrefix).toEqual(undefined);
+      expect(before.css).toEqual(css[0]);
+      expect(after.variableSuffix).toEqual('px');
+      expect(after.css).toEqual(', ');
+    });
+
+    it.only('should get the before and after for the second part of a transform interpolation', () => {
+      const css = [
+        `
+        transform: translate3d(var(--var-test),
+      `,
+        `, 0);`,
+      ];
+
+      const before = cssBeforeInterpolation(css[0]);
+      const after = cssAfterInterpolation(css[1]);
+
+      expect(before.variablePrefix).toEqual(undefined);
+      expect(before.css).toEqual(css[0]);
+      expect(after.variableSuffix).toEqual('');
+      expect(after.css).toEqual(', 0);');
     });
   });
 
@@ -79,82 +114,82 @@ describe('template literal to css', () => {
     it('should extract the suffix with not prefix', () => {
       const simpleParts = ['px'];
 
-      const head = cssAfterInterpolation(simpleParts[0]);
+      const extract = cssAfterInterpolation(simpleParts[0]);
 
-      expect(head.variableSuffix).toEqual('px');
-      expect(head.css).toEqual('');
+      expect(extract.variableSuffix).toEqual('px');
+      expect(extract.css).toEqual('');
     });
 
     it('should extract the prefix of a simple template literal', () => {
       const simpleParts = ['"', '"'];
 
-      const head = cssBeforeInterpolation(simpleParts[0]);
+      const extract = cssBeforeInterpolation(simpleParts[0]);
 
-      expect(head.variablePrefix).toEqual('"');
-      expect(head.css).toEqual('');
+      expect(extract.variablePrefix).toEqual('"');
+      expect(extract.css).toEqual('');
     });
 
     it('should extract the suffix of a simple template literal', () => {
       const simpleParts = ['"', '"'];
 
-      const head = cssAfterInterpolation(simpleParts[1]);
+      const extract = cssAfterInterpolation(simpleParts[1]);
 
-      expect(head.variableSuffix).toEqual('"');
-      expect(head.css).toEqual('');
+      expect(extract.variableSuffix).toEqual('"');
+      expect(extract.css).toEqual('');
     });
 
     it('should extract prefix from css calac function', () => {
       const complexPartsNoPropertyName = ['calc(100% - ', 'px)'];
 
-      const head = cssBeforeInterpolation(complexPartsNoPropertyName[0]);
+      const extract = cssBeforeInterpolation(complexPartsNoPropertyName[0]);
 
-      expect(head.variablePrefix).toEqual(undefined);
-      expect(head.css).toEqual('calc(100% - ');
+      expect(extract.variablePrefix).toEqual(undefined);
+      expect(extract.css).toEqual('calc(100% - ');
     });
 
     it('should extract suffix from css calc function', () => {
       const complexPartsNoPropertyName = ['calc(100% - ', 'px)'];
 
-      const head = cssAfterInterpolation(complexPartsNoPropertyName[1]);
+      const extract = cssAfterInterpolation(complexPartsNoPropertyName[1]);
 
-      expect(head.variableSuffix).toEqual('px');
-      expect(head.css).toEqual(')');
+      expect(extract.variableSuffix).toEqual('px');
+      expect(extract.css).toEqual(')');
     });
 
     it('should extract first part of a three part value', () => {
       const complexPartsNoPropertyName = ['transform3d(', ', ', ')'];
 
-      const head = cssBeforeInterpolation(complexPartsNoPropertyName[0]);
+      const extract = cssBeforeInterpolation(complexPartsNoPropertyName[0]);
 
-      expect(head.variablePrefix).toEqual(undefined);
-      expect(head.css).toEqual('transform3d(');
+      expect(extract.variablePrefix).toEqual(undefined);
+      expect(extract.css).toEqual('transform3d(');
     });
 
     it('should extract before second part of a three part value', () => {
       const complexPartsNoPropertyName = ['transform3d(', ', ', ')'];
 
-      const head = cssBeforeInterpolation(complexPartsNoPropertyName[1]);
+      const extract = cssBeforeInterpolation(complexPartsNoPropertyName[1]);
 
-      expect(head.variablePrefix).toEqual(undefined);
-      expect(head.css).toEqual(', ');
+      expect(extract.variablePrefix).toEqual(undefined);
+      expect(extract.css).toEqual(', ');
     });
 
     it('should extract after second part of a three part value', () => {
       const complexPartsNoPropertyName = ['transform3d(', ', ', ')'];
 
-      const head = cssAfterInterpolation(complexPartsNoPropertyName[1]);
+      const extract = cssAfterInterpolation(complexPartsNoPropertyName[1]);
 
-      expect(head.variableSuffix).toEqual('');
-      expect(head.css).toEqual(', ');
+      expect(extract.variableSuffix).toEqual('');
+      expect(extract.css).toEqual(', ');
     });
 
     it('should extract second part of a three part value', () => {
       const complexPartsNoPropertyName = ['transform3d(', ', ', ')'];
 
-      const head = cssAfterInterpolation(complexPartsNoPropertyName[2]);
+      const extract = cssAfterInterpolation(complexPartsNoPropertyName[2]);
 
-      expect(head.variableSuffix).toEqual('');
-      expect(head.css).toEqual(')');
+      expect(extract.variableSuffix).toEqual('');
+      expect(extract.css).toEqual(')');
     });
   });
 });

--- a/packages/ts-transform/src/utils/__tests__/template-literal-to-css.test.tsx
+++ b/packages/ts-transform/src/utils/__tests__/template-literal-to-css.test.tsx
@@ -1,0 +1,59 @@
+import { cssBeforeInterpolation, cssAfterInterpolation } from '../template-literal-to-css';
+
+describe('template literal to css', () => {
+  describe('interpolations', () => {
+    it('should extract the prefix of a simple template literal', () => {
+      const simpleParts = ['content: "', '";font-color:blue;'];
+
+      const head = cssBeforeInterpolation(simpleParts[0]);
+
+      expect(head.variablePrefix).toEqual('"');
+      expect(head.css).toEqual('content: ');
+    });
+
+    it('should extract the suffix of a simple template literal', () => {
+      const simpleParts = ['content: "', '";font-color:blue;'];
+
+      const head = cssAfterInterpolation(simpleParts[1]);
+
+      expect(head.variableSuffix).toEqual('"');
+      expect(head.css).toEqual(';font-color:blue;');
+    });
+
+    it('should extract the prefix of a complex template literal', () => {
+      const complexParts = ['transform: translateX(', ');color:blue;'];
+
+      const head = cssBeforeInterpolation(complexParts[0]);
+
+      expect(head.variablePrefix).toEqual('');
+      expect(head.css).toEqual('transform: translateX(');
+    });
+
+    it('should extract the suffix of a complex template literal', () => {
+      const complexParts = ['transform: translateX(', ');color:blue;'];
+
+      const head = cssAfterInterpolation(complexParts[1]);
+
+      expect(head.variableSuffix).toEqual('');
+      expect(head.css).toEqual(');color:blue;');
+    });
+
+    it('should extract prefix without preceeding property declaration', () => {
+      const complexPartsNoPropertyName = ['calc(100% - ', 'px)'];
+
+      const head = cssBeforeInterpolation(complexPartsNoPropertyName[0]);
+
+      expect(head.variablePrefix).toEqual(undefined);
+      expect(head.css).toEqual('calc(100% - ');
+    });
+
+    it('should extract suffix without teminating colon', () => {
+      const complexPartsNoPropertyName = ['calc(100% - ', 'px)'];
+
+      const head = cssAfterInterpolation(complexPartsNoPropertyName[1]);
+
+      expect(head.variableSuffix).toEqual('px');
+      expect(head.css).toEqual(')');
+    });
+  });
+});

--- a/packages/ts-transform/src/utils/__tests__/template-literal-to-css.test.tsx
+++ b/packages/ts-transform/src/utils/__tests__/template-literal-to-css.test.tsx
@@ -75,13 +75,7 @@ describe('template literal to css', () => {
     });
 
     it('should get the before and after for the first part of a transform interpolation', () => {
-      const css = [
-        `
-        transform: translate3d(
-      `,
-        `px, `,
-        `, 0);`,
-      ];
+      const css = [`transform: translate3d(`, `px, `, `, 0);`];
 
       const before = cssBeforeInterpolation(css[0]);
       const after = cssAfterInterpolation(css[1]);
@@ -92,19 +86,14 @@ describe('template literal to css', () => {
       expect(after.css).toEqual(', ');
     });
 
-    it.only('should get the before and after for the second part of a transform interpolation', () => {
-      const css = [
-        `
-        transform: translate3d(var(--var-test),
-      `,
-        `, 0);`,
-      ];
+    it('should get the before and after for the second part of a transform interpolation', () => {
+      const css = [`\n            transform: translate3d(var(--var-test), `, `, 0);`];
 
       const before = cssBeforeInterpolation(css[0]);
       const after = cssAfterInterpolation(css[1]);
 
       expect(before.variablePrefix).toEqual(undefined);
-      expect(before.css).toEqual(css[0]);
+      expect(before.css).toEqual('\n            transform: translate3d(var(--var-test), ');
       expect(after.variableSuffix).toEqual('');
       expect(after.css).toEqual(', 0);');
     });

--- a/packages/ts-transform/src/utils/__tests__/template-literal-to-css.test.tsx
+++ b/packages/ts-transform/src/utils/__tests__/template-literal-to-css.test.tsx
@@ -37,6 +37,42 @@ describe('template literal to css', () => {
       expect(head.variableSuffix).toEqual('');
       expect(head.css).toEqual(');color:blue;');
     });
+
+    it('should extract first part of a three part value', () => {
+      const complexPartsNoPropertyName = ['transform: transform3d(', ', ', ')'];
+
+      const head = cssBeforeInterpolation(complexPartsNoPropertyName[0]);
+
+      expect(head.variablePrefix).toEqual(undefined);
+      expect(head.css).toEqual('transform: transform3d(');
+    });
+
+    it('should extract before second part of a three part value', () => {
+      const complexPartsNoPropertyName = ['transform: transform3d(', ', ', ')'];
+
+      const head = cssBeforeInterpolation(complexPartsNoPropertyName[1]);
+
+      expect(head.variablePrefix).toEqual(undefined);
+      expect(head.css).toEqual(', ');
+    });
+
+    it('should extract after second part of a three part value', () => {
+      const complexPartsNoPropertyName = ['transform: transform3d(', ', ', ')'];
+
+      const head = cssAfterInterpolation(complexPartsNoPropertyName[1]);
+
+      expect(head.variableSuffix).toEqual('');
+      expect(head.css).toEqual(', ');
+    });
+
+    it('should extract second part of a three part value', () => {
+      const complexPartsNoPropertyName = ['transform: transform3d(', ', ', ')'];
+
+      const head = cssAfterInterpolation(complexPartsNoPropertyName[2]);
+
+      expect(head.variableSuffix).toEqual('');
+      expect(head.css).toEqual(')');
+    });
   });
 
   describe('interpolations without surrounding css', () => {
@@ -82,6 +118,42 @@ describe('template literal to css', () => {
       const head = cssAfterInterpolation(complexPartsNoPropertyName[1]);
 
       expect(head.variableSuffix).toEqual('px');
+      expect(head.css).toEqual(')');
+    });
+
+    it('should extract first part of a three part value', () => {
+      const complexPartsNoPropertyName = ['transform3d(', ', ', ')'];
+
+      const head = cssBeforeInterpolation(complexPartsNoPropertyName[0]);
+
+      expect(head.variablePrefix).toEqual(undefined);
+      expect(head.css).toEqual('transform3d(');
+    });
+
+    it('should extract before second part of a three part value', () => {
+      const complexPartsNoPropertyName = ['transform3d(', ', ', ')'];
+
+      const head = cssBeforeInterpolation(complexPartsNoPropertyName[1]);
+
+      expect(head.variablePrefix).toEqual(undefined);
+      expect(head.css).toEqual(', ');
+    });
+
+    it('should extract after second part of a three part value', () => {
+      const complexPartsNoPropertyName = ['transform3d(', ', ', ')'];
+
+      const head = cssAfterInterpolation(complexPartsNoPropertyName[1]);
+
+      expect(head.variableSuffix).toEqual('');
+      expect(head.css).toEqual(', ');
+    });
+
+    it('should extract second part of a three part value', () => {
+      const complexPartsNoPropertyName = ['transform3d(', ', ', ')'];
+
+      const head = cssAfterInterpolation(complexPartsNoPropertyName[2]);
+
+      expect(head.variableSuffix).toEqual('');
       expect(head.css).toEqual(')');
     });
   });

--- a/packages/ts-transform/src/utils/__tests__/template-literal-to-css.test.tsx
+++ b/packages/ts-transform/src/utils/__tests__/template-literal-to-css.test.tsx
@@ -1,7 +1,7 @@
 import { cssBeforeInterpolation, cssAfterInterpolation } from '../template-literal-to-css';
 
 describe('template literal to css', () => {
-  describe('interpolations', () => {
+  describe('interpolations with surrounding css', () => {
     it('should extract the prefix of a simple template literal', () => {
       const simpleParts = ['content: "', '";font-color:blue;'];
 
@@ -25,7 +25,7 @@ describe('template literal to css', () => {
 
       const head = cssBeforeInterpolation(complexParts[0]);
 
-      expect(head.variablePrefix).toEqual('');
+      expect(head.variablePrefix).toEqual(undefined);
       expect(head.css).toEqual('transform: translateX(');
     });
 
@@ -37,8 +37,37 @@ describe('template literal to css', () => {
       expect(head.variableSuffix).toEqual('');
       expect(head.css).toEqual(');color:blue;');
     });
+  });
 
-    it('should extract prefix without preceeding property declaration', () => {
+  describe('interpolations without surrounding css', () => {
+    it('should extract the suffix with not prefix', () => {
+      const simpleParts = ['px'];
+
+      const head = cssAfterInterpolation(simpleParts[0]);
+
+      expect(head.variableSuffix).toEqual('px');
+      expect(head.css).toEqual('');
+    });
+
+    it('should extract the prefix of a simple template literal', () => {
+      const simpleParts = ['"', '"'];
+
+      const head = cssBeforeInterpolation(simpleParts[0]);
+
+      expect(head.variablePrefix).toEqual('"');
+      expect(head.css).toEqual('');
+    });
+
+    it('should extract the suffix of a simple template literal', () => {
+      const simpleParts = ['"', '"'];
+
+      const head = cssAfterInterpolation(simpleParts[1]);
+
+      expect(head.variableSuffix).toEqual('"');
+      expect(head.css).toEqual('');
+    });
+
+    it('should extract prefix from css calac function', () => {
       const complexPartsNoPropertyName = ['calc(100% - ', 'px)'];
 
       const head = cssBeforeInterpolation(complexPartsNoPropertyName[0]);
@@ -47,7 +76,7 @@ describe('template literal to css', () => {
       expect(head.css).toEqual('calc(100% - ');
     });
 
-    it('should extract suffix without teminating colon', () => {
+    it('should extract suffix from css calc function', () => {
       const complexPartsNoPropertyName = ['calc(100% - ', 'px)'];
 
       const head = cssAfterInterpolation(complexPartsNoPropertyName[1]);

--- a/packages/ts-transform/src/utils/array.tsx
+++ b/packages/ts-transform/src/utils/array.tsx
@@ -1,0 +1,13 @@
+export const unique = <TArrItem extends {}>(
+  arr: TArrItem[],
+  getId: (item: TArrItem) => any = item => item
+): TArrItem[] => {
+  return arr.reduce((acc, item) => {
+    const id = getId(item);
+    if (!acc.find(find => getId(find) === id)) {
+      acc.push(item);
+    }
+
+    return acc;
+  }, [] as TArrItem[]);
+};

--- a/packages/ts-transform/src/utils/string-interpolations.tsx
+++ b/packages/ts-transform/src/utils/string-interpolations.tsx
@@ -1,0 +1,75 @@
+/**
+ * This module is kind of a mess.
+ * Let's get it working first and then fix it up later.
+ * There must be a better way than what we're doing, just needs some thought first.
+ */
+
+/**
+ * Extracts a suffix from a css property e.g:
+ * 'px;font-size: 20px; would return "px" as the suffix and ";font-size: 20px;" as rest.
+ */
+export const cssAfterInterpolation = (css: string): { css: string; variableSuffix?: string } => {
+  let variableSuffix = '';
+
+  if (css.includes('(') || css[0] === ' ' || css[0] === '\n' || css[0] === ';' || css[0] === ',') {
+    css = css;
+  } else {
+    let cssIndex;
+    // when calc property used, we get ')' along with unit in the 'literal' object
+    // Eg. `marginLeft: calc(100% - ${obj.key}rem)` will give ')rem' in the span literal
+    if (css.indexOf(')') !== -1) {
+      cssIndex = css.indexOf(')');
+    } else if (css.indexOf(';') !== -1) {
+      cssIndex = css.indexOf(';');
+    } else if (css.indexOf(',') !== -1) {
+      cssIndex = css.indexOf(',');
+    } else if (css.indexOf('\n') !== -1) {
+      cssIndex = css.indexOf('\n');
+    } else {
+      cssIndex = css.length;
+    }
+
+    variableSuffix = css.slice(0, cssIndex);
+    css = css.slice(cssIndex);
+  }
+
+  return {
+    variableSuffix,
+    css,
+  };
+};
+
+export const cssBeforeInterpolation = (css: string): { css: string; variablePrefix?: string } => {
+  const trimCss = css.trim();
+  if (
+    trimCss[trimCss.length - 1] === '(' ||
+    trimCss[0] === ',' ||
+    trimCss[trimCss.length - 1] === ','
+  ) {
+    // We are inside a css like "translateX(".
+    // There is no prefix we need to extract here.
+    return {
+      css: css,
+      variablePrefix: undefined,
+    };
+  }
+
+  if (!css.match(/:|;/) && !css.includes('(')) {
+    return {
+      variablePrefix: css,
+      css: '',
+    };
+  }
+
+  let variablePrefix = css.match(/:(.+$)/)?.[1];
+  if (variablePrefix) {
+    variablePrefix = variablePrefix.trim();
+    const lastIndex = css.lastIndexOf(variablePrefix);
+    css = css.slice(0, lastIndex);
+  }
+
+  return {
+    css,
+    variablePrefix,
+  };
+};

--- a/packages/ts-transform/src/utils/template-literal-to-css.tsx
+++ b/packages/ts-transform/src/utils/template-literal-to-css.tsx
@@ -6,78 +6,7 @@ import { objectLiteralToCssString } from './object-literal-to-css';
 import { extractCssVarFromArrowFunction } from './extract-css-var-from-arrow-function';
 import { evaluateFunction, isReturnCssLike } from './evalulate-function';
 import { joinToBinaryExpression, joinThreeExpressions } from './expression-operators';
-
-/**
- * Extracts a suffix from a css property e.g:
- * 'px;font-size: 20px; would return "px" as the suffix and ";font-size: 20px;" as rest.
- */
-export const cssAfterInterpolation = (tail: string): { css: string; variableSuffix?: string } => {
-  let variableSuffix = '';
-  let css = '';
-
-  if (tail[0] === '\n' || tail[0] === ';' || tail[0] === ',') {
-    css = tail;
-  } else {
-    // Sometimes people forget to put a semi-colon at the end.
-    let tailIndex;
-    // when calc property used, we get ')' along with unit in the 'literal' object
-    // Eg. `marginLeft: calc(100% - ${obj.key}rem)` will give ')rem' in the span literal
-    if (tail.indexOf(')') !== -1) {
-      tailIndex = tail.indexOf(')');
-    } else if (tail.indexOf(';') !== -1) {
-      tailIndex = tail.indexOf(';');
-    } else if (tail.indexOf(',') !== -1) {
-      tailIndex = tail.indexOf(',');
-    } else if (tail.indexOf('\n') !== -1) {
-      tailIndex = tail.indexOf('\n');
-    } else {
-      tailIndex = tail.length;
-    }
-
-    variableSuffix = tail.slice(0, tailIndex);
-    css = tail.slice(tailIndex);
-  }
-
-  return {
-    variableSuffix,
-    css,
-  };
-};
-
-export const cssBeforeInterpolation = (css: string): { css: string; variablePrefix?: string } => {
-  const trimCss = css.trim();
-  if (
-    trimCss[trimCss.length - 1] === '(' ||
-    trimCss[0] === ',' ||
-    trimCss[trimCss.length - 1] === ','
-  ) {
-    // We are inside a css like "translateX(".
-    // There is no prefix we need to extract here.
-    return {
-      css: css,
-      variablePrefix: undefined,
-    };
-  }
-
-  if (!css.match(/:|;/) && !css.includes('(')) {
-    return {
-      variablePrefix: css,
-      css: '',
-    };
-  }
-
-  let variablePrefix = css.match(/:(.+$)/)?.[1];
-  if (variablePrefix) {
-    variablePrefix = variablePrefix.trim();
-    const lastIndex = css.lastIndexOf(variablePrefix);
-    css = css.slice(0, lastIndex);
-  }
-
-  return {
-    css,
-    variablePrefix,
-  };
-};
+import { cssAfterInterpolation, cssBeforeInterpolation } from './string-interpolations';
 
 export const templateLiteralToCss = (
   node: ts.TemplateExpression | ts.NoSubstitutionTemplateLiteral | ts.StringLiteral,

--- a/packages/ts-transform/src/utils/template-literal-to-css.tsx
+++ b/packages/ts-transform/src/utils/template-literal-to-css.tsx
@@ -15,7 +15,7 @@ export const cssAfterInterpolation = (tail: string): { css: string; variableSuff
   let variableSuffix = '';
   let css = '';
 
-  if (tail[0] === '\n' || tail[0] === ';') {
+  if (tail[0] === '\n' || tail[0] === ';' || tail[0] === ',') {
     css = tail;
   } else {
     // Sometimes people forget to put a semi-colon at the end.
@@ -48,7 +48,7 @@ export const cssAfterInterpolation = (tail: string): { css: string; variableSuff
 };
 
 export const cssBeforeInterpolation = (css: string): { css: string; variablePrefix?: string } => {
-  if (css[css.length - 1] === '(') {
+  if (css[css.length - 1] === '(' || css[0] === ',') {
     // We are inside a css like "translateX(".
     // There is no prefix we need to extract here.
     return {

--- a/packages/ts-transform/src/utils/template-literal-to-css.tsx
+++ b/packages/ts-transform/src/utils/template-literal-to-css.tsx
@@ -11,12 +11,12 @@ import { joinToBinaryExpression, joinThreeExpressions } from './expression-opera
  * Extracts a suffix from a css property e.g:
  * 'px;font-size: 20px; would return "px" as the suffix and ";font-size: 20px;" as rest.
  */
-const extractSuffix = (tail: string) => {
-  let suffix = '';
-  let rest = '';
+export const cssAfterInterpolation = (tail: string): { css: string; variableSuffix?: string } => {
+  let variableSuffix = '';
+  let css = '';
 
   if (tail[0] === '\n' || tail[0] === ';') {
-    rest = tail;
+    css = tail;
   } else {
     // Sometimes people forget to put a semi-colon at the end.
     let tailIndex;
@@ -37,30 +37,30 @@ const extractSuffix = (tail: string) => {
       tailIndex = tail.length;
     }
 
-    suffix = tail.slice(0, tailIndex);
-    rest = tail.slice(tailIndex);
-    if (!rest) {
-      rest = ';';
+    variableSuffix = tail.slice(0, tailIndex);
+    css = tail.slice(tailIndex);
+    if (!css) {
+      css = ';';
     }
   }
 
   return {
-    suffix,
-    rest,
+    variableSuffix,
+    css,
   };
 };
 
-const extractPrefix = (css: string): { css: string; prefix?: string } => {
-  let prefix = css.match(/:(.+$)/)?.[1];
-  if (prefix) {
-    prefix = prefix.trim();
-    const lastIndex = css.lastIndexOf(prefix);
+export const cssBeforeInterpolation = (css: string): { css: string; variablePrefix?: string } => {
+  let variablePrefix = css.match(/:(.+$)/)?.[1];
+  if (variablePrefix) {
+    variablePrefix = variablePrefix.trim();
+    const lastIndex = css.lastIndexOf(variablePrefix);
     css = css.slice(0, lastIndex);
   }
 
   return {
     css,
-    prefix,
+    variablePrefix,
   };
 };
 
@@ -104,28 +104,27 @@ export const templateLiteralToCss = (
         css += result.css;
         cssVariables = cssVariables.concat(result.cssVariables);
       } else if (ts.isStringLiteral(value.initializer) || ts.isNumericLiteral(value.initializer)) {
-        const extractedPrefix = extractPrefix(css);
+        const before = cssBeforeInterpolation(css);
         // We an an inline arrow function - e.g. css`${props => props.color}`
-        const extractedSuffix = extractSuffix(span.literal.text);
-        const result = extractSuffix(span.literal.text);
+        const after = cssAfterInterpolation(span.literal.text);
 
-        css = extractedPrefix.css;
+        css = before.css;
         let cssVariableExpression: ts.Expression = span.expression;
 
-        if (extractedSuffix.suffix && extractedPrefix.prefix) {
+        if (after.variableSuffix && before.variablePrefix) {
           cssVariableExpression = joinThreeExpressions(
-            ts.createStringLiteral(extractedPrefix.prefix),
+            ts.createStringLiteral(before.variablePrefix),
             span.expression,
-            ts.createStringLiteral(extractedSuffix.suffix)
+            ts.createStringLiteral(after.variableSuffix)
           );
-        } else if (extractedSuffix.suffix) {
+        } else if (after.variableSuffix) {
           cssVariableExpression = joinToBinaryExpression(
             span.expression,
-            ts.createStringLiteral(extractedSuffix.suffix)
+            ts.createStringLiteral(after.variableSuffix)
           );
-        } else if (extractedPrefix.prefix) {
+        } else if (before.variablePrefix) {
           cssVariableExpression = joinToBinaryExpression(
-            ts.createStringLiteral(extractedPrefix.prefix),
+            ts.createStringLiteral(before.variablePrefix),
             span.expression
           );
         }
@@ -134,7 +133,7 @@ export const templateLiteralToCss = (
           name: variableName,
           expression: cssVariableExpression,
         });
-        css += `var(${variableName})${result.rest}`;
+        css += `var(${variableName})${after.css}`;
       } else if (ts.isArrowFunction(value.initializer)) {
         // We found a arrow func expression e.g. const funcVar = () => ({}); css`${funcVar}`
         // We want to "execute" it and then add the result to the css.
@@ -152,28 +151,28 @@ export const templateLiteralToCss = (
         });
       }
     } else if (ts.isArrowFunction(span.expression)) {
-      const extractedPrefix = extractPrefix(css);
+      const before = cssBeforeInterpolation(css);
       // We an an inline arrow function - e.g. css`${props => props.color}`
-      const extractedSuffix = extractSuffix(span.literal.text);
+      const after = cssAfterInterpolation(span.literal.text);
       const result = extractCssVarFromArrowFunction(span.expression, context);
 
-      css = extractedPrefix.css;
+      css = before.css;
       let cssVariableExpression: ts.Expression = result.expression;
 
-      if (extractedSuffix.suffix && extractedPrefix.prefix) {
+      if (after.variableSuffix && before.variablePrefix) {
         cssVariableExpression = joinThreeExpressions(
-          ts.createStringLiteral(extractedPrefix.prefix),
+          ts.createStringLiteral(before.variablePrefix),
           result.expression,
-          ts.createStringLiteral(extractedSuffix.suffix)
+          ts.createStringLiteral(after.variableSuffix)
         );
-      } else if (extractedSuffix.suffix) {
+      } else if (after.variableSuffix) {
         cssVariableExpression = joinToBinaryExpression(
           result.expression,
-          ts.createStringLiteral(extractedSuffix.suffix)
+          ts.createStringLiteral(after.variableSuffix)
         );
-      } else if (extractedPrefix.prefix) {
+      } else if (before.variablePrefix) {
         cssVariableExpression = joinToBinaryExpression(
-          ts.createStringLiteral(extractedPrefix.prefix),
+          ts.createStringLiteral(before.variablePrefix),
           result.expression
         );
       }
@@ -182,7 +181,7 @@ export const templateLiteralToCss = (
         name: result.name,
         expression: cssVariableExpression,
       });
-      css += `var(${result.name})${extractedSuffix.rest}`;
+      css += `var(${result.name})${after.css}`;
     } else if (ts.isCallExpression(span.expression)) {
       // We found a call expression - e.g. const funcVar = () => ({}); css`${funcVar()}`
       const key = getIdentifierText(span.expression.expression);
@@ -211,26 +210,25 @@ export const templateLiteralToCss = (
         });
       }
     } else if (ts.isPropertyAccessExpression(span.expression)) {
-      const extractedPrefix = extractPrefix(css);
-      const extractedSuffix = extractSuffix(span.literal.text);
-      const result = extractSuffix(span.literal.text);
-      css = extractedPrefix.css;
+      const before = cssBeforeInterpolation(css);
+      const after = cssAfterInterpolation(span.literal.text);
+      css = before.css;
       let cssVariableExpression: ts.Expression = span.expression;
 
-      if (extractedSuffix.suffix && extractedPrefix.prefix) {
+      if (after.variableSuffix && before.variablePrefix) {
         cssVariableExpression = joinThreeExpressions(
-          ts.createStringLiteral(extractedPrefix.prefix),
+          ts.createStringLiteral(before.variablePrefix),
           span.expression,
-          ts.createStringLiteral(extractedSuffix.suffix)
+          ts.createStringLiteral(after.variableSuffix)
         );
-      } else if (extractedSuffix.suffix) {
+      } else if (after.variableSuffix) {
         cssVariableExpression = joinToBinaryExpression(
           span.expression,
-          ts.createStringLiteral(extractedSuffix.suffix)
+          ts.createStringLiteral(after.variableSuffix)
         );
-      } else if (extractedPrefix.prefix) {
+      } else if (before.variablePrefix) {
         cssVariableExpression = joinToBinaryExpression(
-          ts.createStringLiteral(extractedPrefix.prefix),
+          ts.createStringLiteral(before.variablePrefix),
           span.expression
         );
       }
@@ -239,7 +237,7 @@ export const templateLiteralToCss = (
         name: variableName,
         expression: cssVariableExpression,
       });
-      css += `var(${variableName})${result.rest}`;
+      css += `var(${variableName})${after.css}`;
     } else if (
       ts.isExpressionStatement(span.expression) ||
       ts.isConditionalExpression(span.expression) ||

--- a/packages/ts-transform/src/utils/template-literal-to-css.tsx
+++ b/packages/ts-transform/src/utils/template-literal-to-css.tsx
@@ -26,14 +26,11 @@ export const cssAfterInterpolation = (tail: string): { css: string; variableSuff
       tailIndex = tail.indexOf(')');
     } else if (tail.indexOf(';') !== -1) {
       tailIndex = tail.indexOf(';');
+    } else if (tail.indexOf(',') !== -1) {
+      tailIndex = tail.indexOf(',');
     } else if (tail.indexOf('\n') !== -1) {
       tailIndex = tail.indexOf('\n');
     } else {
-      tailIndex = tail.length;
-    }
-
-    if (tailIndex === -1) {
-      // Ok still nothing. This means everything is a suffix!
       tailIndex = tail.length;
     }
 

--- a/packages/ts-transform/src/utils/template-literal-to-css.tsx
+++ b/packages/ts-transform/src/utils/template-literal-to-css.tsx
@@ -39,9 +39,6 @@ export const cssAfterInterpolation = (tail: string): { css: string; variableSuff
 
     variableSuffix = tail.slice(0, tailIndex);
     css = tail.slice(tailIndex);
-    if (!css) {
-      css = ';';
-    }
   }
 
   return {
@@ -51,6 +48,22 @@ export const cssAfterInterpolation = (tail: string): { css: string; variableSuff
 };
 
 export const cssBeforeInterpolation = (css: string): { css: string; variablePrefix?: string } => {
+  if (css[css.length - 1] === '(') {
+    // We are inside a css like "translateX(".
+    // There is no prefix we need to extract here.
+    return {
+      css,
+      variablePrefix: undefined,
+    };
+  }
+
+  if (!css.match(/:|;/) && !css.includes('(')) {
+    return {
+      variablePrefix: css,
+      css: '',
+    };
+  }
+
   let variablePrefix = css.match(/:(.+$)/)?.[1];
   if (variablePrefix) {
     variablePrefix = variablePrefix.trim();

--- a/packages/ts-transform/src/utils/template-literal-to-css.tsx
+++ b/packages/ts-transform/src/utils/template-literal-to-css.tsx
@@ -45,11 +45,16 @@ export const cssAfterInterpolation = (tail: string): { css: string; variableSuff
 };
 
 export const cssBeforeInterpolation = (css: string): { css: string; variablePrefix?: string } => {
-  if (css[css.length - 1] === '(' || css[0] === ',') {
+  const trimCss = css.trim();
+  if (
+    trimCss[trimCss.length - 1] === '(' ||
+    trimCss[0] === ',' ||
+    trimCss[trimCss.length - 1] === ','
+  ) {
     // We are inside a css like "translateX(".
     // There is no prefix we need to extract here.
     return {
-      css,
+      css: css,
       variablePrefix: undefined,
     };
   }


### PR DESCRIPTION
Closes #130 

TODO
- [x] fix multiple group interpoations being broken

```
linear-gradient(45deg, ${N30} 25%, transparent 25%),
    linear-gradient(-45deg, ${N30} 25%, transparent 25%),
    linear-gradient(45deg, transparent 75%, ${N30} 75%),
    linear-gradient(-45deg, transparent 75%, ${N30} 75%);
```