### PR TITLE
chore: configure global types for jest

### DIFF
--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -1,5 +1,4 @@
 import { transformSync, TransformOptions } from '@babel/core';
-import 'jest-extended';
 import compiledPlugin from '../index';
 
 const babelOpts: TransformOptions = {

--- a/packages/css-in-js/src/__tests__/browser.test.tsx
+++ b/packages/css-in-js/src/__tests__/browser.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import 'jest-extended';
 import { styled } from '@compiled/css-in-js';
 
 describe('browser', () => {

--- a/packages/css-in-js/src/__tests__/ssr.test.tsx
+++ b/packages/css-in-js/src/__tests__/ssr.test.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import 'jest-extended';
 import { styled, CC } from '@compiled/css-in-js';
 
 describe('SSR', () => {

--- a/packages/css-in-js/src/class-names/__tests__/index.test.tsx
+++ b/packages/css-in-js/src/class-names/__tests__/index.test.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { ClassNames } from '@compiled/css-in-js';
-import '@compiled/jest-css-in-js';
 
 describe('class names component', () => {
   it('should create css from object literal', () => {

--- a/packages/css-in-js/src/jsx/__tests__/index.test.tsx
+++ b/packages/css-in-js/src/jsx/__tests__/index.test.tsx
@@ -1,7 +1,6 @@
 import '@compiled/css-in-js';
 import React from 'react';
 import { render } from '@testing-library/react';
-import '@compiled/jest-css-in-js';
 
 describe('css prop', () => {
   it('should create css from object literal', () => {

--- a/packages/css-in-js/src/styled/__tests__/index.test.tsx
+++ b/packages/css-in-js/src/styled/__tests__/index.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { styled } from '@compiled/css-in-js';
 import { em } from 'polished';
-import '@compiled/jest-css-in-js';
 
 describe('styled component', () => {
   it('should render a simple styled div using an object', () => {

--- a/packages/style/src/__tests__/style-ssr.test.tsx
+++ b/packages/style/src/__tests__/style-ssr.test.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import 'jest-extended';
 import Style from '../style';
 
 describe('<Style />', () => {

--- a/packages/style/src/__tests__/style.test.tsx
+++ b/packages/style/src/__tests__/style.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import 'jest-extended';
 import Style from '../style';
 
 describe('<Style />', () => {

--- a/packages/ts-transform/src/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/__tests__/index.test.tsx
@@ -1,6 +1,5 @@
 import * as ts from 'typescript';
 import { Transformer } from 'ts-transformer-testing-library';
-import 'jest-extended';
 import rootTransformer from '../index';
 
 const stubProgam: ts.Program = ({

--- a/packages/ts-transform/src/class-names/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/class-names/__tests__/index.test.tsx
@@ -1,6 +1,5 @@
 import * as ts from 'typescript';
 import { Transformer } from 'ts-transformer-testing-library';
-import 'jest-extended';
 import classNamesTransformer from '../index';
 
 jest.mock('../../utils/hash');

--- a/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
@@ -1,6 +1,5 @@
 import * as ts from 'typescript';
 import { Transformer } from 'ts-transformer-testing-library';
-import 'jest-extended';
 import cssPropTransformer from '../index';
 
 jest.mock('../../utils/hash');

--- a/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
@@ -1,6 +1,5 @@
 import * as ts from 'typescript';
 import { Transformer } from 'ts-transformer-testing-library';
-import 'jest-extended';
 import styledComponentTransformer from '../index';
 
 jest.mock('../../utils/hash');

--- a/test/global.d.ts
+++ b/test/global.d.ts
@@ -1,0 +1,2 @@
+import '@compiled/jest-css-in-js';
+import 'jest-extended';


### PR DESCRIPTION
Using configuration suggested by `jest-extended`.
https://github.com/jest-community/jest-extended#typescript

Fixes #176.