### PR TITLE
replace css in js imports with style imports

### DIFF
--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -37,7 +37,7 @@ describe('babel plugin', () => {
 
     expect(output?.code).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       const StyledDiv = /*#__PURE__*/React.forwardRef(({
         as: C = \\"div\\",
         ...props
@@ -63,7 +63,7 @@ describe('babel plugin', () => {
 
     expect(output?.code).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       const StyledDiv = /*#__PURE__*/React.forwardRef(({
         as: C = \\"div\\",
         ...props
@@ -88,7 +88,7 @@ describe('babel plugin', () => {
 
     expect(output?.code).toMatchInlineSnapshot(`
       "import React from 'react';
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       <CC><CS hash=\\"1iqe21w\\">{[\\".cc-1iqe21w{font-size:12px}\\"]}</CS><div className=\\"cc-1iqe21w\\" /></CC>;"
     `);
   });
@@ -107,7 +107,7 @@ describe('babel plugin', () => {
 
     expect(output?.code).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       <CC><CS hash=\\"31m7m\\">{[\\".cc-1iqe21w{font-size:12px}\\"]}</CS><div className={\\"cc-1iqe21w\\"} /></CC>;"
     `);
   });

--- a/packages/css-in-js/src/__tests__/ssr.test.tsx
+++ b/packages/css-in-js/src/__tests__/ssr.test.tsx
@@ -3,7 +3,8 @@
  */
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { styled, CC } from '@compiled/css-in-js';
+import { styled } from '@compiled/css-in-js';
+import { CC } from '@compiled/style';
 
 describe('SSR', () => {
   it('should render styles inline', () => {

--- a/packages/ts-transform/src/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/__tests__/index.test.tsx
@@ -86,7 +86,7 @@ describe('root transformer', () => {
 
     expect(actual.outputText).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       <CC><CS hash=\\"1b1wq3m\\">{[\\".cc-1b1wq3m{font-size:20px}\\\\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1vZHVsZS50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBRVEiLCJmaWxlIjoibW9kdWxlLnRzeCIsInNvdXJjZXNDb250ZW50IjpbIlxuICAgICAgICBpbXBvcnQgJ0Bjb21waWxlZC9jc3MtaW4tanMnO1xuICAgICAgICA8ZGl2IGNzcz17eyBmb250U2l6ZTogJzIwcHgnIH19PmhlbGxvIHdvcmxkPC9kaXY+XG4gICAgICAiXX0= */\\"]}</CS><div className=\\"cc-1b1wq3m\\">hello world</div></CC>;
       "
     `);
@@ -106,7 +106,7 @@ describe('root transformer', () => {
 
     expect(actual.outputText).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       /*#__PURE__*/ React.forwardRef(({ as: C = \\"div\\", ...props }, ref) => <CC><CS hash=\\"1b1wq3m\\">{[\\".cc-1b1wq3m{font-size:20px}\\\\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1vZHVsZS50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR1EiLCJmaWxlIjoibW9kdWxlLnRzeCIsInNvdXJjZXNDb250ZW50IjpbIlxuICAgICAgICBpbXBvcnQgeyBzdHlsZWQgfSBmcm9tICdAY29tcGlsZWQvY3NzLWluLWpzJztcblxuICAgICAgICBzdHlsZWQuZGl2KHsgZm9udFNpemU6IDIwIH0pO1xuICAgICAgIl19 */\\"]}</CS><C {...props} ref={ref} className={\\"cc-1b1wq3m\\" + (props.className ? \\" \\" + props.className : \\"\\")}/></CC>);
       "
     `);
@@ -126,7 +126,7 @@ describe('root transformer', () => {
 
     expect(actual.outputText).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       <CC><CS hash=\\"gpurwr\\">{[\\".cc-1b1wq3m{font-size:20px}\\\\n/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIm1vZHVsZS50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR1EiLCJmaWxlIjoibW9kdWxlLnRzeCIsInNvdXJjZXNDb250ZW50IjpbIlxuICAgICAgICBpbXBvcnQgeyBDbGFzc05hbWVzIH0gZnJvbSAnQGNvbXBpbGVkL2Nzcy1pbi1qcyc7XG5cbiAgICAgICAgPENsYXNzTmFtZXM+eyh7IGNzcyB9KSA9PiA8ZGl2IGNsYXNzTmFtZT17Y3NzKHsgZm9udFNpemU6IDIwIH0pfSAvPn08L0NsYXNzTmFtZXM+XG4gICAgICAiXX0= */\\"]}</CS><div className={\\"cc-1b1wq3m\\"}/></CC>;
       "
     `);
@@ -145,7 +145,7 @@ describe('root transformer', () => {
       createTsConfig(transformer)
     );
 
-    expect(actual.outputText).toInclude("import { CC, CS } from '@compiled/css-in-js'");
+    expect(actual.outputText).toInclude('import { CC, CS } from "@compiled/style"');
   });
 
   it('should match react import when transforming to common js', () => {
@@ -222,7 +222,7 @@ describe('root transformer', () => {
 
     expect(actual.outputText).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       /*#__PURE__*/ React.forwardRef(({ as: C = \\"div\\", ...props }, ref) => <CC><CS hash=\\"1x3e11p\\">{[\\".cc-1x3e11p{font-size:12px}\\"]}</CS><C {...props} ref={ref} className={\\"cc-1x3e11p\\" + (props.className ? \\" \\" + props.className : \\"\\")}/></CC>);
       "
     `);
@@ -242,7 +242,7 @@ describe('root transformer', () => {
 
     expect(actual.outputText).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       <CC><CS hash=\\"1iqe21w\\">{[\\".cc-1iqe21w{font-size:12px}\\"]}</CS><div className=\\"cc-1iqe21w\\"/></CC>;
       "
     `);
@@ -264,7 +264,7 @@ describe('root transformer', () => {
 
     expect(actual.outputText).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       <CC><CS hash=\\"31m7m\\">{[\\".cc-1iqe21w{font-size:12px}\\"]}</CS><div className={\\"cc-1iqe21w\\"}/></CC>;
       "
     `);

--- a/packages/ts-transform/src/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/__tests__/index.test.tsx
@@ -164,9 +164,9 @@ describe('root transformer', () => {
       "\\"use strict\\";
       Object.defineProperty(exports, \\"__esModule\\", { value: true });
       const react_1 = require(\\"react\\");
-      const css_in_js_1 = require(\\"@compiled/css-in-js\\");
-      react_1.default.createElement(css_in_js_1.CC, null,
-          react_1.default.createElement(css_in_js_1.CS, { hash: '1b1wq3m' }, [\\".cc-1b1wq3m{font-size:20px}\\"]),
+      const style_1 = require(\\"@compiled/css-in-js\\");
+      react_1.default.createElement(style_1.CC, null,
+          react_1.default.createElement(style_1.CS, { hash: '1b1wq3m' }, [\\".cc-1b1wq3m{font-size:20px}\\"]),
           react_1.default.createElement(\\"div\\", { className: 'cc-1b1wq3m' }, \\"hello world\\"));
       "
     `);

--- a/packages/ts-transform/src/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/__tests__/index.test.tsx
@@ -164,7 +164,7 @@ describe('root transformer', () => {
       "\\"use strict\\";
       Object.defineProperty(exports, \\"__esModule\\", { value: true });
       const react_1 = require(\\"react\\");
-      const style_1 = require(\\"@compiled/css-in-js\\");
+      const style_1 = require(\\"@compiled/style\\");
       react_1.default.createElement(style_1.CC, null,
           react_1.default.createElement(style_1.CS, { hash: '1b1wq3m' }, [\\".cc-1b1wq3m{font-size:20px}\\"]),
           react_1.default.createElement(\\"div\\", { className: 'cc-1b1wq3m' }, \\"hello world\\"));

--- a/packages/ts-transform/src/constants.tsx
+++ b/packages/ts-transform/src/constants.tsx
@@ -14,7 +14,7 @@ export const CLASSNAME_PROP_NAME = 'className';
 
 // Identifiers
 export const REACT_PACKAGE_NAME = 'react';
-export const COMMON_JS_COMPILED_IMPORT = 'css_in_js_1';
+export const COMMON_JS_COMPILED_IMPORT = 'style_1';
 export const REACT_DEFAULT_IMPORT = 'React';
 export const REACT_COMMON_JS_IMPORT_1 = 'react_1';
 export const STYLED_AS_PROP_NAME = 'as';

--- a/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
@@ -55,7 +55,7 @@ describe('css prop transformer', () => {
       <div css={{}}>hello world</div>
     `);
 
-    expect(actual).toIncludeRepeated(`import { CC, CS } from '@compiled/css-in-js';`, 1);
+    expect(actual).toIncludeRepeated(`import { CC, CS } from \"@compiled/style\";`, 1);
   });
 
   it('should pass through style identifier when there is no dynamic styles in the css', () => {

--- a/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
@@ -24,7 +24,7 @@ describe('styled component transformer', () => {
 
     expect(actual).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       const ListItem = /*#__PURE__*/ React.forwardRef(({ as: C = \\"div\\", ...props }, ref) => <CC><CS hash=\\"css-test\\">{[\\".css-test{font-size:20px}\\"]}</CS><C {...props} ref={ref} className={\\"css-test\\" + (props.className ? \\" \\" + props.className : \\"\\")}/></CC>);
       if (process.env.NODE_ENV === \\"development\\") {
           ListItem.displayName = \\"ListItem\\";
@@ -94,7 +94,7 @@ describe('styled component transformer', () => {
 
     expect(actual).toMatchInlineSnapshot(`
       "import React from \\"react\\";
-      import { CC, CS } from '@compiled/css-in-js';
+      import { CC, CS } from \\"@compiled/style\\";
       const ListItem = /*#__PURE__*/ React.forwardRef(({ as: C = \\"div\\", ...props }, ref) => <CC><CS hash=\\"css-test\\">{[\\".css-test{font-size:20px}\\"]}</CS><C {...props} ref={ref} className={\\"css-test\\" + (props.className ? \\" \\" + props.className : \\"\\")}/></CC>);
       if (process.env.NODE_ENV === \\"development\\") {
           ListItem.displayName = \\"ListItem\\";

--- a/packages/ts-transform/src/utils/visit-source-file-ensure-style-import.tsx
+++ b/packages/ts-transform/src/utils/visit-source-file-ensure-style-import.tsx
@@ -40,7 +40,6 @@ export const visitSourceFileEnsureStyleImport = (
 
       // if it exists already, then just remove the removedImports from the importstatement.
 
-      const defaultImport = node.importClause && node.importClause.name;
       let namedImports: ts.ImportSpecifier[] = [];
 
       // remove namedImports that have been flagged for removal.
@@ -63,7 +62,7 @@ export const visitSourceFileEnsureStyleImport = (
         node,
         /* decorators */ undefined,
         /* modifiers */ undefined,
-        ts.createImportClause(defaultImport, ts.createNamedImports(namedImports)),
+        ts.createImportClause(undefined, ts.createNamedImports(namedImports)),
         node.moduleSpecifier
       );
       // if we hit an import we should check if any sibling nodes are

--- a/packages/ts-transform/src/utils/visit-source-file-ensure-style-import.tsx
+++ b/packages/ts-transform/src/utils/visit-source-file-ensure-style-import.tsx
@@ -34,11 +34,6 @@ export const visitSourceFileEnsureStyleImport = (
       node.moduleSpecifier.text === COMPILED_PKG
     ) {
       log.log('ensuring style export is defined');
-      // if a style import doesn't exist, add it as a sibling to this node
-      // idealy this should occur in a separate transform, possibly as an independent transform
-      // before any of the three processes start.
-
-      // if it exists already, then just remove the removedImports from the importstatement.
 
       let namedImports: ts.ImportSpecifier[] = [];
 

--- a/packages/ts-transform/src/utils/visit-source-file-ensure-style-import.tsx
+++ b/packages/ts-transform/src/utils/visit-source-file-ensure-style-import.tsx
@@ -3,61 +3,92 @@ import * as log from './log';
 import * as constants from '../constants';
 
 const COMPILED_PKG = '@compiled/css-in-js';
+const COMPILED_STYLE_PKG = '@compiled/style';
 
 interface Opts {
   imports?: string[];
   removeNamedImport?: string;
 }
 
+const isStylePkgFound = (sourceFile: ts.SourceFile | ts.ModuleBlock): boolean => {
+  return !!sourceFile.statements.find(
+    (statement: ts.Node) =>
+      ts.isImportDeclaration(statement) &&
+      ts.isStringLiteral(statement.moduleSpecifier) &&
+      statement.moduleSpecifier.text.startsWith(COMPILED_STYLE_PKG)
+  );
+};
+
 export const visitSourceFileEnsureStyleImport = (
   sourceFile: ts.SourceFile,
   context: ts.TransformationContext,
   {
-    imports = [constants.COMPILED_STYLE_COMPONENT_NAME, constants.COMPILED_COMPONENT_NAME],
+    imports = [constants.COMPILED_COMPONENT_NAME, constants.COMPILED_STYLE_COMPONENT_NAME],
     removeNamedImport,
   }: Opts = {}
 ): ts.SourceFile => {
-  const visitor = (node: ts.Node): ts.Node => {
+  const visitor = (node: ts.Node): ts.Node | Array<ts.Node> => {
     if (
       ts.isImportDeclaration(node) &&
       ts.isStringLiteral(node.moduleSpecifier) &&
       node.moduleSpecifier.text === COMPILED_PKG
     ) {
       log.log('ensuring style export is defined');
+      // if a style import doesn't exist, add it as a sibling to this node
+      // idealy this should occur in a separate transform, possibly as an independent transform
+      // before any of the three processes start.
+
+      // if it exists already, then just remove the removedImports from the importstatement.
 
       const defaultImport = node.importClause && node.importClause.name;
       let namedImports: ts.ImportSpecifier[] = [];
 
+      // remove namedImports that have been flagged for removal.
       if (
         node.importClause &&
         node.importClause.namedBindings &&
         ts.isNamedImports(node.importClause.namedBindings)
       ) {
         namedImports = Array.from(node.importClause.namedBindings.elements).filter(imp => {
+          const filteredImports = [...imports];
           if (removeNamedImport) {
-            return imp.name.text !== removeNamedImport;
+            filteredImports.push(removeNamedImport);
           }
 
-          return true;
+          return !filteredImports.includes(imp.name.text);
         });
       }
 
-      imports.forEach(name => {
-        if (!namedImports.some(val => val.name.text === name)) {
-          // "CC" isn't being imported yet. Add it!
-          namedImports = [ts.createImportSpecifier(undefined, ts.createIdentifier(name))].concat(
-            namedImports
-          );
-        }
-      });
-
-      return ts.updateImportDeclaration(
+      const updatedNode = ts.updateImportDeclaration(
         node,
         /* decorators */ undefined,
         /* modifiers */ undefined,
         ts.createImportClause(defaultImport, ts.createNamedImports(namedImports)),
         node.moduleSpecifier
       );
+      // if we hit an import we should check if any sibling nodes are
+      // @compiled/style
+      if (!isStylePkgFound(sourceFile)) {
+        // Add the package
+        // update the importSpecifier appropriately.
+
+        const styleImports = imports.map(name => {
+          return ts.createImportSpecifier(undefined, ts.createIdentifier(name));
+        });
+
+        const styleImportDeclaration = ts.createImportDeclaration(
+          /* decorators */ undefined,
+          /* modifiers */ undefined,
+          ts.createImportClause(undefined, ts.createNamedImports(styleImports)),
+          ts.createLiteral(COMPILED_STYLE_PKG)
+        );
+
+        return namedImports.length ? [updatedNode, styleImportDeclaration] : styleImportDeclaration;
+      } else {
+        // if it is found, check the length of the namedImports array
+        // if its 0, remove the namedImports node.
+        return namedImports.length ? updatedNode : ts.createEmptyStatement();
+      }
     }
 
     return ts.visitEachChild(node, visitor, context);

--- a/packages/ts-transform/src/utils/visit-source-file-ensure-style-import.tsx
+++ b/packages/ts-transform/src/utils/visit-source-file-ensure-style-import.tsx
@@ -27,7 +27,7 @@ export const visitSourceFileEnsureStyleImport = (
     removeNamedImport,
   }: Opts = {}
 ): ts.SourceFile => {
-  const visitor = (node: ts.Node): ts.Node | Array<ts.Node> => {
+  const visitor = (node: ts.Node): ts.Node | Array<ts.Node> | undefined => {
     if (
       ts.isImportDeclaration(node) &&
       ts.isStringLiteral(node.moduleSpecifier) &&
@@ -87,7 +87,7 @@ export const visitSourceFileEnsureStyleImport = (
       } else {
         // if it is found, check the length of the namedImports array
         // if its 0, remove the namedImports node.
-        return namedImports.length ? updatedNode : ts.createEmptyStatement();
+        return namedImports.length ? updatedNode : undefined;
       }
     }
 


### PR DESCRIPTION
PR for #103 
Remaining issues with this PR (failing tests): 
- *css-in-js_1 is undefined*: Failing tests in css-in-js package, running that test-suite gives us a few errors about `css-in-js_1` being undefined. Looks like the common-js bundle transpiles the exports from @compiled/style down to `style_1`, I've made changes in ts-transform constants to account for this, but for reasons I do not know the css-in-js test suite still fails (do i need to run a fresh build?)

- *dangling semi-colons for removed nodes* , in this implementation we're inserting a sibling node via `visit-source-file-ensure-style-import`. on subsequent invocations of this fn, we remove the `compiled-css-in-js` import if there are no more namedImports. Oddly removals after an insertion of a sibling node via `[newNode, node]` returns a dangling semi-colon while doing so without insertions does not. 

@madou  if you have insight into any of the above, let me know. 

**Aside** We should probably separate `visit-source-file-ensure-style-import` into two separate operations now: 
* The first checks if an import from `@compiled/style` exists in the sourceFile, if it doesn't it inserts `import { CC, CS } from @compiled/style` if it does, then it does nothing. 
* The second is basically the existing logic, filtering out namedImports marked for removal from "@compiled/css-in-js", until no namedImports exist (at which point the node is removed)

^ would have done this in this PR, but a) wanted an MVP of this and b) to  check that there wasn't anything blocking us from doing this.