### PR TITLE
fix: short circuits css variable expressions to an empty string that have a prefix or suffix

### DIFF
--- a/packages/ts-transform/src/class-names/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/class-names/__tests__/index.test.tsx
@@ -338,7 +338,7 @@ describe('class names transformer', () => {
       `);
 
       expect(actual).toInclude(
-        '<div style={{ "--var-test-fontsize": fontSize + "px" }} className={"css-test"}>hello, world!</div>'
+        '<div style={{ "--var-test-fontsize": (fontSize || "") + "px" }} className={"css-test"}>hello, world!</div>'
       );
       expect(actual).toInclude('.css-test{font-size:var(--var-test-fontsize)}');
     });

--- a/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/css-prop/__tests__/index.test.tsx
@@ -770,7 +770,7 @@ describe('css prop transformer', () => {
         <div css={{ marginLeft: \`\${heading.depth}rem\` }}>hello world</div>
       `);
 
-      expect(actual).toInclude('style={{ "--var-test": heading.depth + "rem" }}');
+      expect(actual).toInclude('style={{ "--var-test": (heading.depth || "") + "rem" }}');
       expect(actual).toInclude('.css-test{margin-left:var(--var-test)}');
     });
 
@@ -800,7 +800,7 @@ describe('css prop transformer', () => {
         <div css={{ marginLeft: \`calc(100% - \${heading.depth}rem)\` }}>hello world</div>
       `);
 
-      expect(actual).toInclude('style={{ "--var-test": heading.depth + "rem" }}');
+      expect(actual).toInclude('style={{ "--var-test": (heading.depth || "") + "rem" }}');
       expect(actual).toInclude('.css-test{margin-left:calc(100% - var(--var-test))}');
     });
 

--- a/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
+++ b/packages/ts-transform/src/styled-component/__tests__/index.test.tsx
@@ -103,6 +103,18 @@ describe('styled component transformer', () => {
     `);
   });
 
+  it('should shortcircuit props with suffix to a empty string to avoid undefined in css', () => {
+    const actual = transformer.transform(`
+      import { styled } from '@compiled/css-in-js';
+
+      const ListItem = styled.div\`
+        font-size: \${props => props.color}px;
+      \`;
+    `);
+
+    expect(actual).toInclude('"--var-test-propscolor": (props.color || "") + "px"');
+  });
+
   it('should add react default import if missing', () => {
     const actual = transformer.transform(`
       import { styled } from '@compiled/css-in-js';
@@ -227,7 +239,7 @@ describe('styled component transformer', () => {
 
       expect(actual).toInclude('.css-test{font-size:var(--var-test-propstextsize)}');
       expect(actual).toInclude('textSize, ...props }');
-      expect(actual).toInclude('"--var-test-propstextsize": textSize + "px"');
+      expect(actual).toInclude('"--var-test-propstextsize": (textSize || "") + "px"');
     });
 
     it('should persist suffix of dynamic property value into inline styles', () => {
@@ -444,7 +456,7 @@ describe('styled component transformer', () => {
         \`;
       `);
 
-      expect(actual).toInclude('"--var-test-propscolor": "super" + props.color + "big"');
+      expect(actual).toInclude('"--var-test-propscolor": "super" + (props.color || "") + "big"');
     });
 
     it('should move any prefix of a dynamic arrow func property into the style property', () => {
@@ -456,7 +468,7 @@ describe('styled component transformer', () => {
         \`;
       `);
 
-      expect(actual).toInclude('"--var-test-propscolor": "super" + props.color');
+      expect(actual).toInclude('"--var-test-propscolor": "super" + (props.color || "")');
     });
 
     it('should move suffix and prefix of a dynamic property into the style property', () => {
@@ -568,7 +580,7 @@ describe('styled component transformer', () => {
       expect(actual).toInclude(
         '<CS hash="css-test">{[".css-test{border-radius:var(--var-test-br);color:red}"]}</CS>'
       );
-      expect(actual).toInclude('style={{ ...props.style, "--var-test-br": br + "px" }}');
+      expect(actual).toInclude('style={{ ...props.style, "--var-test-br": (br || "") + "px" }}');
     });
 
     it('should transform inline arrow function with suffix', () => {
@@ -635,7 +647,9 @@ describe('styled component transformer', () => {
       expect(actual).toInclude(
         '<CS hash="css-test">{[".css-test{font-size:var(--var-test-getbr);color:red}"]}</CS>'
       );
-      expect(actual).toInclude('style={{ ...props.style, "--var-test-getbr": getBr() + "px" }}');
+      expect(actual).toInclude(
+        'style={{ ...props.style, "--var-test-getbr": (getBr() || "") + "px" }}'
+      );
     });
 
     it.todo('should transform template string with argument function variable');
@@ -761,7 +775,7 @@ describe('styled component transformer', () => {
 
       expect(actual).toInclude('textSize, ...props }');
       expect(actual).toInclude('.css-test{font-size:var(--var-test-propstextsize)}');
-      expect(actual).toInclude('"--var-test-propstextsize": textSize + "px"');
+      expect(actual).toInclude('"--var-test-propstextsize": (textSize || "") + "px"');
     });
 
     it('should persist suffix of dynamic property value into inline styles', () => {
@@ -775,7 +789,7 @@ describe('styled component transformer', () => {
         });
       `);
 
-      expect(actual).toInclude('"--var-test-propsfontsize": props.fontSize + "px" }}');
+      expect(actual).toInclude('"--var-test-propsfontsize": (props.fontSize || "") + "px" }}');
       expect(actual).toInclude('.css-test{font-size:var(--var-test-propsfontsize)}');
     });
 

--- a/packages/ts-transform/src/utils/expression-operators.tsx
+++ b/packages/ts-transform/src/utils/expression-operators.tsx
@@ -39,6 +39,14 @@ export function joinToJsxExpression(
   );
 }
 
+export const shortCircuitToEmptyString = (left: ts.Expression): ts.BinaryExpression => {
+  return ts.createBinary(
+    left,
+    ts.createToken(ts.SyntaxKind.BarBarToken),
+    ts.createStringLiteral('')
+  );
+};
+
 /**
  * left + right
  */

--- a/packages/ts-transform/src/utils/template-literal-to-css.tsx
+++ b/packages/ts-transform/src/utils/template-literal-to-css.tsx
@@ -5,7 +5,11 @@ import { cssVariableHash } from './hash';
 import { objectLiteralToCssString } from './object-literal-to-css';
 import { extractCssVarFromArrowFunction } from './extract-css-var-from-arrow-function';
 import { evaluateFunction, isReturnCssLike } from './evalulate-function';
-import { joinToBinaryExpression, joinThreeExpressions } from './expression-operators';
+import {
+  joinToBinaryExpression,
+  joinThreeExpressions,
+  shortCircuitToEmptyString,
+} from './expression-operators';
 import {
   cssAfterInterpolation,
   cssBeforeInterpolation,
@@ -25,18 +29,18 @@ const buildCssVariableExpression = (
   if (after.variableSuffix && before.variablePrefix) {
     cssVariableExpression = joinThreeExpressions(
       ts.createStringLiteral(before.variablePrefix),
-      initialExpression,
+      shortCircuitToEmptyString(initialExpression),
       ts.createStringLiteral(after.variableSuffix)
     );
   } else if (after.variableSuffix) {
     cssVariableExpression = joinToBinaryExpression(
-      initialExpression,
+      shortCircuitToEmptyString(initialExpression),
       ts.createStringLiteral(after.variableSuffix)
     );
   } else if (before.variablePrefix) {
     cssVariableExpression = joinToBinaryExpression(
       ts.createStringLiteral(before.variablePrefix),
-      initialExpression
+      shortCircuitToEmptyString(initialExpression)
     );
   }
 


### PR DESCRIPTION
Closes #84 